### PR TITLE
Support specifying multiple proposals in check macro

### DIFF
--- a/fontspector-checkapi/src/check.rs
+++ b/fontspector-checkapi/src/check.rs
@@ -56,7 +56,7 @@ pub struct Check<'a> {
     /// A short description of the check
     pub rationale: &'a str,
     /// URL where the check was proposed
-    pub proposal: &'a str,
+    pub proposal: &'a [&'a str],
     /// Function pointer implementing the actual check
     pub implementation: CheckImplementation<'a>,
     /// Function pointer implementing a hotfix to the binary file

--- a/fontspector-checkhelper/src/check.rs
+++ b/fontspector-checkhelper/src/check.rs
@@ -118,7 +118,8 @@ pub(crate) fn check_impl(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut new_sig = sig.clone();
     new_sig.ident = impl_ident.clone();
 
-    let proposal_items: Vec<syn::LitStr> = params.proposal
+    let proposal_items: Vec<syn::LitStr> = params
+        .proposal
         .iter()
         .map(|ident| syn::LitStr::new(&ident.to_string(), Span::call_site()))
         .collect();
@@ -157,7 +158,12 @@ pub(crate) fn check_impl(args: TokenStream, input: TokenStream) -> TokenStream {
         id.value(),
         title.value(),
         new_rationale,
-        params.proposal.iter().map(|i| i.to_string()).collect::<Vec<_>>().join(" and ")
+        params
+            .proposal
+            .iter()
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
     );
     quote!(
         #(#attrs)*

--- a/fontspector-cli/src/reporters/markdown.rs
+++ b/fontspector-cli/src/reporters/markdown.rs
@@ -116,7 +116,7 @@ impl Reporter for MarkdownReporter {
             "experimental_checks": experimental_checks,
             "succinct": args.succinct,
             "total": results.len(),
-            "proposal": proposals,
+            "proposals": proposals,
         });
         let context = &Context::from_serialize(val).unwrap_or_else(|e| {
             log::error!("Error creating Markdown context: {:}", e);

--- a/fontspector-cli/src/reporters/markdown.rs
+++ b/fontspector-cli/src/reporters/markdown.rs
@@ -95,10 +95,15 @@ impl Reporter for MarkdownReporter {
         }
         let summary = results.summary();
 
-        let proposals: HashMap<String, String> = registry
+        let proposals: HashMap<String, Vec<String>> = registry
             .checks
             .iter()
-            .map(|(k, v)| (k.clone(), v.proposal.to_string()))
+            .map(|(k, v)| {
+                (
+                    k.clone(),
+                    v.proposal.iter().map(|s| s.to_string()).collect(),
+                )
+            })
             .collect();
 
         let val: serde_json::Value = json!({

--- a/profile-googlefonts/src/checks/googlefonts/color_fonts.rs
+++ b/profile-googlefonts/src/checks/googlefonts/color_fonts.rs
@@ -16,7 +16,11 @@ const NANOEMOJI_ADVICE : &str = "You can do it by using the maximum_color tool p
         run the maximum_color tool in nanoemoji:
         https://github.com/googlefonts/nanoemoji
     ",
-    proposal = "https://googlefonts.github.io/gf-guide/color.html and https://github.com/fonttools/fontbakery/issues/3886 and https://github.com/fonttools/fontbakery/issues/3888 and https://github.com/fonttools/fontbakery/pull/3889 and https://github.com/fonttools/fontbakery/issues/4131",
+    proposal = "https://googlefonts.github.io/gf-guide/color.html",
+    proposal = "https://github.com/fonttools/fontbakery/issues/3886",
+    proposal = "https://github.com/fonttools/fontbakery/issues/3888",
+    proposal = "https://github.com/fonttools/fontbakery/pull/3889",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4131",
     title = "Ensure font has the expected color font tables."
 )]
 fn color_fonts(t: &Testable, _context: &Context) -> CheckFnResult {

--- a/profile-googlefonts/src/checks/googlefonts/description/broken_links.rs
+++ b/profile-googlefonts/src/checks/googlefonts/description/broken_links.rs
@@ -13,7 +13,8 @@ use crate::network_conditions::get_url;
         all hyperlinks in it must be properly working.
     
     ",
-    proposal = "https://github.com/fonttools/fontbakery/issues/4110 and https://github.com/fonttools/fontbakery/issues/4829",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4110",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4829",
     title = "Does DESCRIPTION file contain broken links?",
     applies_to = "DESC"
 )]

--- a/profile-googlefonts/src/checks/googlefonts/description/has_article.rs
+++ b/profile-googlefonts/src/checks/googlefonts/description/has_article.rs
@@ -9,7 +9,9 @@ use fontspector_checkapi::prelude::*;
         not both - except for Noto fonts which should have both!
     
     ",
-    proposal = "https://github.com/fonttools/fontbakery/issues/3841 and https://github.com/fonttools/fontbakery/issues/4318 and https://github.com/fonttools/fontbakery/issues/4702",
+    proposal = "https://github.com/fonttools/fontbakery/issues/3841",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4318",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4702",
     title = "Check for presence of an ARTICLE.en_us.html file",
     implementation = "all"
 )]

--- a/profile-googlefonts/src/checks/googlefonts/description/urls.rs
+++ b/profile-googlefonts/src/checks/googlefonts/description/urls.rs
@@ -12,7 +12,8 @@ use scraper::{Html, Selector};
         text content of anchors not to include the http:// or https:// prefixes.
     
     ",
-    proposal = "https://github.com/fonttools/fontbakery/issues/3497 and https://github.com/fonttools/fontbakery/issues/4283",
+    proposal = "https://github.com/fonttools/fontbakery/issues/3497",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4283",
     title = "URLs on DESCRIPTION file must not display http(s) prefix.",
     applies_to = "DESC"
 )]

--- a/profile-googlefonts/src/checks/googlefonts/description/valid_html.rs
+++ b/profile-googlefonts/src/checks/googlefonts/description/valid_html.rs
@@ -15,7 +15,8 @@ use scraper::{Html, Selector};
         description file or edited by hand.
     
     ",
-    proposal = "https://github.com/fonttools/fontbakery/issues/2664 and https://github.com/fonttools/fontbakery/issues/4829",
+    proposal = "https://github.com/fonttools/fontbakery/issues/2664",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4829",
     title = "Is this a proper HTML snippet?",
     applies_to = "DESC"
 )]

--- a/profile-googlefonts/src/checks/googlefonts/font_copyright.rs
+++ b/profile-googlefonts/src/checks/googlefonts/font_copyright.rs
@@ -44,7 +44,8 @@ use crate::constants::EXPECTED_COPYRIGHT_PATTERN;
          (https://github.com/Omnibus-Type/ArchivoBlack)\"
 
     ",
-    proposal = "https://github.com/fonttools/fontbakery/pull/2383 and https://github.com/fonttools/fontbakery/issues/4829",
+    proposal = "https://github.com/fonttools/fontbakery/pull/2383",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4829",
     title = "Copyright notices match canonical pattern in fonts",
     implementation = "all"
 )]

--- a/profile-googlefonts/src/checks/googlefonts/name/license_url.rs
+++ b/profile-googlefonts/src/checks/googlefonts/name/license_url.rs
@@ -59,7 +59,8 @@ fn identify_license(name_string: &str) -> Option<&'static License> {
         When in doubt, please choose OFL for new font projects.
     
     ",
-    proposal = "https://github.com/fonttools/fontbakery/issues/4358 and https://github.com/fonttools/fontbakery/issues/4829",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4358",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4829",
     title = "License URL matches License text on name table?"
 )]
 fn license_url(t: &Testable, _context: &Context) -> CheckFnResult {

--- a/profile-googlefonts/src/checks/googlefonts/vendor_id.rs
+++ b/profile-googlefonts/src/checks/googlefonts/vendor_id.rs
@@ -38,7 +38,8 @@ const SUGGEST_MICROSOFT_VENDORLIST_WEBSITE: &str = "If you registered it recentl
         check, since your ID will soon be included in one of our upcoming releases.
     
     ",
-    proposal = "https://github.com/fonttools/fontbakery/issues/3943 and https://github.com/fonttools/fontbakery/issues/4829",
+    proposal = "https://github.com/fonttools/fontbakery/issues/3943",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4829",
     title = "Checking OS/2 achVendID."
 )]
 fn vendor_id(t: &Testable, _context: &Context) -> CheckFnResult {

--- a/profile-opentype/src/checks/opentype/STAT/ital_axis.rs
+++ b/profile-opentype/src/checks/opentype/STAT/ital_axis.rs
@@ -205,7 +205,9 @@ fn check_ital_is_binary_and_last(t: &TestFont, is_italic: bool) -> Result<Vec<St
 
         Also, the axis value name for uprights must be set as elidable.
     ",
-    proposal = "https://github.com/fonttools/fontbakery/issues/2934 and https://github.com/fonttools/fontbakery/issues/3668 and https://github.com/fonttools/fontbakery/issues/3669",
+    proposal = "https://github.com/fonttools/fontbakery/issues/2934",
+    proposal = "https://github.com/fonttools/fontbakery/issues/3668",
+    proposal = "https://github.com/fonttools/fontbakery/issues/3669",
     implementation = "all",
     title = "Ensure VFs have 'ital' STAT axis."
 )]

--- a/profile-opentype/src/checks/opentype/post_table_version.rs
+++ b/profile-opentype/src/checks/opentype/post_table_version.rs
@@ -29,10 +29,10 @@ use read_fonts::TableProvider;
         Acceptable post format versions are 2 and 3 for TTF and OTF CFF2 builds,
         and post format 3 for CFF builds.
     "#,
-    proposal = "https://github.com/fonttools/fontbakery/issues/4829  // legacy check
-                https://github.com/google/fonts/issues/215
-                https://github.com/fonttools/fontbakery/issues/263
-                https://github.com/fonttools/fontbakery/issues/3635",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4829",  // legacy check
+    proposal = "https://github.com/google/fonts/issues/215",
+    proposal = "https://github.com/fonttools/fontbakery/issues/263",
+    proposal = "https://github.com/fonttools/fontbakery/issues/3635",
     title = "Font has correct post table version?"
 )]
 fn post_table_version(t: &Testable, _context: &Context) -> CheckFnResult {

--- a/profile-universal/src/checks/empty_glyph_on_gid1_for_colrv0.rs
+++ b/profile-universal/src/checks/empty_glyph_on_gid1_for_colrv0.rs
@@ -14,7 +14,8 @@ use skrifa::GlyphId;
 
         See https://github.com/googlefonts/gftools/issues/609
     ",
-    proposal = "https://github.com/googlefonts/gftools/issues/609 and https://github.com/fonttools/fontbakery/pull/3905",
+    proposal = "https://github.com/googlefonts/gftools/issues/609",
+    proposal = "https://github.com/fonttools/fontbakery/pull/3905",
     title = "Put an empty glyph on GID 1 right after the .notdef glyph for COLRv0 fonts."
 )]
 fn empty_glyph_on_gid1_for_colrv0(t: &Testable, _context: &Context) -> CheckFnResult {

--- a/profile-universal/src/checks/linegaps.rs
+++ b/profile-universal/src/checks/linegaps.rs
@@ -15,7 +15,8 @@ use read_fonts::TableProvider;
         For better linespacing consistency across platforms,
         (typo/hhea)LineGap values must be 0.
     ",
-    proposal = "https://github.com/fonttools/fontbakery/issues/4133 and https://googlefonts.github.io/gf-guide/metrics.html",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4133",
+    proposal = "https://googlefonts.github.io/gf-guide/metrics.html",
     title = "Checking Vertical Metric linegaps."
 )]
 fn linegaps(t: &Testable, _context: &Context) -> CheckFnResult {

--- a/profile-universal/src/checks/name/char_restrictions.rs
+++ b/profile-universal/src/checks/name/char_restrictions.rs
@@ -11,7 +11,8 @@ use read_fonts::types::NameId;
         an even smaller subset ("a-zA-Z0-9") for
         VARIATIONS_POSTSCRIPT_NAME_PREFIX (nameID 25).
     "#,
-    proposal = "https://github.com/fonttools/fontbakery/issues/1718 and https://github.com/fonttools/fontbakery/issues/1663",
+    proposal = "https://github.com/fonttools/fontbakery/issues/1718",
+    proposal = "https://github.com/fonttools/fontbakery/issues/1663",
     title = "Are there disallowed characters in the NAME table?"
 )]
 fn char_restrictions(t: &Testable, _context: &Context) -> CheckFnResult {

--- a/profile-universal/src/checks/name/family_and_style_max_length.rs
+++ b/profile-universal/src/checks/name/family_and_style_max_length.rs
@@ -33,7 +33,8 @@ fn low_level_names(name: &Name<'_>, name_id: NameId) -> HashMap<(u16, u16, u16),
         This check ensures that the length of name table entries is not
         too long, as this causes problems in some environments.
     ",
-    proposal = "https://github.com/fonttools/fontbakery/issues/1488 and https://github.com/fonttools/fontbakery/issues/2179",
+    proposal = "https://github.com/fonttools/fontbakery/issues/1488",
+    proposal = "https://github.com/fonttools/fontbakery/issues/2179",
     title = "Combined length of family and style must not exceed 32 characters."
 )]
 fn family_and_style_max_length(t: &Testable, _context: &Context) -> CheckFnResult {

--- a/profile-universal/src/checks/soft_hyphen.rs
+++ b/profile-universal/src/checks/soft_hyphen.rs
@@ -19,7 +19,8 @@ use fontspector_checkapi::{prelude::*, testfont, FileTypeConvert};
         More discussion at:
         https://typedrawers.com/discussion/2046/special-dash-things-softhyphen-horizontalbar
     ",
-    proposal = "https://github.com/fonttools/fontbakery/issues/4046 and https://github.com/fonttools/fontbakery/issues/3486",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4046",
+    proposal = "https://github.com/fonttools/fontbakery/issues/3486",
     title = "Does the font contain a soft hyphen?"
 )]
 fn soft_hyphen(t: &Testable, context: &Context) -> CheckFnResult {

--- a/profile-universal/src/checks/whitespace_widths.rs
+++ b/profile-universal/src/checks/whitespace_widths.rs
@@ -17,7 +17,8 @@ use skrifa::MetadataProvider;
         If the space and the nbspace are not the same width, it breaks the text
         composition of documents.
     ",
-    proposal = "https://github.com/fonttools/fontbakery/issues/3843 https://github.com/fonttools/fontbakery/issues/4829",
+    proposal = "https://github.com/fonttools/fontbakery/issues/3843",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4829",
     title = "Space and non-breaking space have the same width?"
 )]
 fn whitespace_widths(t: &Testable, _context: &Context) -> CheckFnResult {


### PR DESCRIPTION
Per #23 , support specifying multiple proposals.

One idea is to support both single and plural (list) proposals such as 
`check(proposal = "1")` and `check(proposal = ["1", "2", "3"]` but I found that in darling the latter is difficult to implement.

Another solution, which is the change adopted in this PR, is to just use darling's `multiple` option so that we write
```
check(
    proposal = "1",
    proposal = "2",
    proposal = "3",
)
```
to specify multiple proposal strings.

Now that the proposals are a list of strings, the `proposal` field is updated from `pub proposal: &'a str,` to `pub proposal: &'a [&'a str],`