### PR TITLE
New check: [googlefonts/separator_glyphs] Ensure non-ink characters are present

### DIFF
--- a/fontspector-checkapi/src/codetesting.rs
+++ b/fontspector-checkapi/src/codetesting.rs
@@ -43,6 +43,7 @@ pub fn run_check(check: Check<'_>, font: Testable) -> Option<CheckResult> {
         check_metadata: check.metadata(),
         full_lists: false,
         cache: Default::default(),
+        overrides: vec![],
     };
     check.run(&TestableType::Single(&font), &ctx, None)
 }

--- a/fontspector-checkapi/src/pens.rs
+++ b/fontspector-checkapi/src/pens.rs
@@ -94,36 +94,6 @@ impl OutlinePen for HasInkPen {
 }
 
 #[derive(Default)]
-/// A pen to determine if an outline has any contours
-pub struct AnythingPen {
-    /// Does the outline have anything?
-    anything: bool,
-}
-impl AnythingPen {
-    /// Create a new AnythingPen
-    pub fn new() -> Self {
-        Self::default()
-    }
-    /// Does the outline have anything?
-    pub fn anything(&self) -> bool {
-        self.anything
-    }
-}
-impl OutlinePen for AnythingPen {
-    fn move_to(&mut self, _x: f32, _y: f32) {}
-    fn line_to(&mut self, _x: f32, _y: f32) {
-        self.anything = true;
-    }
-    fn curve_to(&mut self, _x1: f32, _y1: f32, _x2: f32, _y2: f32, _x3: f32, _y3: f32) {
-        self.anything = true;
-    }
-    fn quad_to(&mut self, _cx0: f32, _cy0: f32, _x: f32, _y: f32) {
-        self.anything = true;
-    }
-    fn close(&mut self) {}
-}
-
-#[derive(Default)]
 /// A pen to count the number of contours in an outline
 pub struct ContourCountPen {
     /// The number of contours in the outline

--- a/fontspector-checkapi/src/profile.rs
+++ b/fontspector-checkapi/src/profile.rs
@@ -5,7 +5,7 @@ use serde_json::{Map, Value};
 use crate::{Check, CheckId, Context, Registry, StatusCode, TestableType};
 use std::collections::HashMap;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 /// An override directive
 ///
 /// Profiles may choose to override the status of a check if the vendor
@@ -14,11 +14,11 @@ use std::collections::HashMap;
 /// and a reason for the override.
 pub struct Override {
     /// Result code to match against
-    code: String,
+    pub code: String,
     /// Overridden status code
-    status: StatusCode,
+    pub status: StatusCode,
     /// Reason for the override
-    reason: String,
+    pub reason: String,
 }
 
 impl Override {
@@ -72,7 +72,7 @@ pub struct Profile {
     /// Overrides
     ///
     /// Override the severity of included checks. See [Override] for more information.
-    overrides: HashMap<CheckId, Vec<Override>>,
+    pub overrides: HashMap<CheckId, Vec<Override>>,
     #[serde(default)]
     /// Configuration defaults
     ///

--- a/fontspector-web/src/lib.rs
+++ b/fontspector-web/src/lib.rs
@@ -52,6 +52,7 @@ pub fn check_fonts(fonts: &JsValue, profile: &str) -> Result<String, JsValue> {
         check_metadata: serde_json::Value::Null,
         full_lists: false,
         cache: Default::default(),
+        overrides: vec![],
     };
     let all_testables: Vec<TestableType> = collection.collection_and_files().collect();
 

--- a/profile-googlefonts/src/checks/googlefonts/mod.rs
+++ b/profile-googlefonts/src/checks/googlefonts/mod.rs
@@ -2,17 +2,26 @@
 #[cfg(not(target_family = "wasm"))]
 mod axes_match;
 
+mod canonical_filename;
+mod cjk_vertical_metrics;
+mod cjk_vertical_metrics_regressions;
 mod color_fonts;
+mod font_copyright;
 mod font_names;
 mod fstype;
 mod fvar_instances;
+mod glyph_coverage;
 mod has_ttfautohint_params;
 mod old_ttfautohint;
 mod render_own_name;
+mod separator_glyphs;
 mod tofu;
 mod unitsperem;
 mod use_typo_metrics;
 mod vendor_id;
+mod version_bump;
+mod vertical_metrics;
+mod vertical_metrics_regressions;
 mod weightclass;
 
 pub mod STAT;
@@ -26,18 +35,15 @@ pub mod license;
 pub mod meta;
 pub mod metadata;
 pub mod name;
+pub mod repo;
 pub mod varfont;
 
 #[cfg(not(target_family = "wasm"))]
 pub use axes_match::axes_match;
-mod canonical_filename;
-mod cjk_vertical_metrics;
-mod font_copyright;
-mod glyph_coverage;
-mod version_bump;
-mod vertical_metrics;
+
 pub use canonical_filename::canonical_filename;
 pub use cjk_vertical_metrics::cjk_vertical_metrics;
+pub use cjk_vertical_metrics_regressions::cjk_vertical_metrics_regressions;
 pub use color_fonts::color_fonts;
 pub use font_copyright::font_copyright;
 pub use font_names::font_names;
@@ -48,15 +54,12 @@ pub use glyph_coverage::glyph_coverage;
 pub use has_ttfautohint_params::has_ttfautohint_params;
 pub use old_ttfautohint::old_ttfautohint;
 pub use render_own_name::render_own_name;
+pub use separator_glyphs::separator_glyphs;
 pub use tofu::tofu;
 pub use unitsperem::unitsperem;
 pub use use_typo_metrics::use_typo_metrics;
 pub use vendor_id::vendor_id;
 pub use version_bump::version_bump;
 pub use vertical_metrics::vertical_metrics;
-pub use weightclass::weightclass;
-mod vertical_metrics_regressions;
 pub use vertical_metrics_regressions::vertical_metrics_regressions;
-mod cjk_vertical_metrics_regressions;
-pub use cjk_vertical_metrics_regressions::cjk_vertical_metrics_regressions;
-pub mod repo;
+pub use weightclass::weightclass;

--- a/profile-googlefonts/src/checks/googlefonts/separator_glyphs.rs
+++ b/profile-googlefonts/src/checks/googlefonts/separator_glyphs.rs
@@ -1,0 +1,35 @@
+use fontspector_checkapi::{prelude::*, testfont, FileTypeConvert};
+
+const SEPARATOR_GLYPHS: [u32; 2] = [
+    0x2028, // LINE SEPARATOR
+    0x2029, // PARAGRAPH SEPARATOR
+];
+
+#[check(
+    id = "googlefonts/separator_glyphs",
+    rationale = "
+        U+2028 and U+2029 should be present; otherwise tofu is displayed.
+        (whitespace_ink will check that they are empty)
+    ",
+    proposal = "https://github.com/fonttools/fontspector/issues/93",
+    title = "Font has correct separator glyphs?"
+)]
+fn separator_glyphs(t: &Testable, context: &Context) -> CheckFnResult {
+    let f = testfont!(t);
+    let codepoints = f.codepoints(Some(context));
+    let missing = SEPARATOR_GLYPHS
+        .iter()
+        .filter(|&&cp| !codepoints.contains(&cp))
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        Ok(Status::just_one_pass())
+    } else {
+        Ok(Status::just_one_warn(
+            "missing-separator-glyphs",
+            &format!(
+                "The following separator glyphs are missing:\n{}",
+                bullet_list(context, missing.iter().map(|&cp| format!("U+{:X}", cp)))
+            ),
+        ))
+    }
+}

--- a/profile-googlefonts/src/lib.rs
+++ b/profile-googlefonts/src/lib.rs
@@ -83,6 +83,7 @@ impl fontspector_checkapi::Plugin for GoogleFonts {
             .add_section("Glyphset Checks")
             .add_and_register_check(checks::googlefonts::glyphsets::shape_languages)
             .add_and_register_check(checks::googlefonts::tofu)
+            .add_and_register_check(checks::googlefonts::separator_glyphs)
             .add_section("Description Checks");
 
         #[cfg(not(target_family = "wasm"))]

--- a/profile-universal/src/checks/empty_letters.rs
+++ b/profile-universal/src/checks/empty_letters.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use fontspector_checkapi::{
     constants::{ALL_HANGUL_SYLLABLES_CODEPOINTS, MODERN_HANGUL_SYLLABLES_CODEPOINTS},
-    pens::AnythingPen,
+    pens::HasInkPen,
     prelude::*,
     testfont, FileTypeConvert, TestFont, DEFAULT_LOCATION,
 };
@@ -93,7 +93,7 @@ fn empty_letters(t: &Testable, context: &Context) -> CheckFnResult {
 }
 
 fn is_blank_glyph(f: &TestFont, gid: GlyphId) -> Result<bool, CheckError> {
-    let mut pen = AnythingPen::default();
+    let mut pen = HasInkPen::default();
     f.draw_glyph(gid, &mut pen, DEFAULT_LOCATION)?;
-    Ok(!pen.anything())
+    Ok(!pen.has_ink())
 }

--- a/profile-universal/src/checks/whitespace_ink.rs
+++ b/profile-universal/src/checks/whitespace_ink.rs
@@ -1,10 +1,10 @@
 use fontspector_checkapi::{
-    pens::AnythingPen, prelude::*, testfont, FileTypeConvert, DEFAULT_LOCATION,
+    pens::HasInkPen, prelude::*, testfont, FileTypeConvert, DEFAULT_LOCATION,
 };
 use skrifa::MetadataProvider;
 use unicode_properties::{GeneralCategory, UnicodeGeneralCategory};
 
-const EXTRA_NON_DRAWING: [u32; 4] = [0x180E, 0x200B, 0x2060, 0xFEFF];
+const EXTRA_NON_DRAWING: [u32; 6] = [0x180E, 0x200B, 0x2028, 0x2029, 0x2060, 0xFEFF];
 const BUT_NOT: [u32; 2] = [0xAD, 0x1680];
 
 #[check(
@@ -16,6 +16,7 @@ const BUT_NOT: [u32; 2] = [0xAD, 0x1680];
            empty, the result will be text layout that is not as expected.
        ",
     proposal = "https://github.com/fonttools/fontbakery/issues/4829",
+    proposal = "https://github.com/fonttools/fontspector/issues/93",
     title = "Whitespace glyphs have ink?"
 )]
 fn whitespace_ink(t: &Testable, context: &Context) -> CheckFnResult {
@@ -41,14 +42,10 @@ fn whitespace_ink(t: &Testable, context: &Context) -> CheckFnResult {
             (cp, gid)
         })
         .filter(|(_cp, gid)| {
-            let mut anythingpen = AnythingPen::new();
-            f.draw_glyph(*gid, &mut anythingpen, DEFAULT_LOCATION)
+            let mut has_ink_pen = HasInkPen::new();
+            f.draw_glyph(*gid, &mut has_ink_pen, DEFAULT_LOCATION)
                 .ok()
-                .and(if anythingpen.anything() {
-                    Some(())
-                } else {
-                    None
-                })
+                .and(has_ink_pen.has_ink().then_some(()))
                 .is_some()
         })
         .map(|(_cp, gid)| f.glyph_name_for_id_synthesise(gid))


### PR DESCRIPTION
Fixes #93.

Also adds profile/configuration file overrides.