### PR TITLE
Fix font_version parsing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,9 @@ jobs:
           pytest tests --verbose
   deploy-binaries:
     name: Build and upload binaries
+    permissions:
+      contents: write
+      id-token: write
     runs-on: ${{ matrix.os.os }}
     # Only build on main or tag
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Run tests
         run: |
-          cargo test --verbose
+          cargo test --verbose --workspace
           pip install maturin pytest
           cd fontspector-py
           maturin build

--- a/fontspector-checkhelper/src/lib.rs
+++ b/fontspector-checkhelper/src/lib.rs
@@ -28,7 +28,9 @@ use check::check_impl;
 ///
 /// Example:
 ///
-/// ```rust
+/// ```ignore
+/// use fontspector_api::prelude::*; // Includes this macro
+///
 /// #[check(
 ///    id = "example_check",
 ///   title = "Example Check",

--- a/profile-googlefonts/src/checks/googlefonts/font_copyright.rs
+++ b/profile-googlefonts/src/checks/googlefonts/font_copyright.rs
@@ -17,7 +17,6 @@ use crate::{checks::googlefonts::metadata::family_proto, constants::EXPECTED_COP
         notice within the METADATA.pb file is not too long; if it is more than 500
         characters, this may be an indication that either a full license or the
         font's description has been included in this field by mistake.
-
     
         The expected pattern for the copyright string adheres to the following rules:
 

--- a/profile-googlefonts/src/checks/googlefonts/license/OFL_copyright.rs
+++ b/profile-googlefonts/src/checks/googlefonts/license/OFL_copyright.rs
@@ -6,7 +6,6 @@ use fontspector_checkapi::prelude::*;
     rationale = "
         
         An OFL.txt file's first line should be the font copyright.
-
     
         The expected pattern for the copyright string adheres to the following rules:
 

--- a/profile-universal/src/checks/STAT_in_statics.rs
+++ b/profile-universal/src/checks/STAT_in_statics.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 
 use fontspector_checkapi::{prelude::*, skip, testfont, FileTypeConvert};
-use skrifa::raw::{tables::stat::AxisValue, TableProvider};
-use skrifa::Tag;
+use skrifa::{
+    raw::{tables::stat::AxisValue, TableProvider},
+    Tag,
+};
 
 #[check(
     id = "STAT_in_statics",
@@ -18,7 +20,7 @@ use skrifa::Tag;
         the designspace. i.e. a Regular weight static should only have the following
         entry for the weight axis:
 
-        ```
+        ```xml
         <AxisIndex value=\"0\"/>
         <Flags value=\"2\"/>  <!-- ElidableAxisValueName -->
         <ValueNameID value=\"265\"/>  <!-- Regular -->

--- a/profile-universal/src/checks/smart_dropout.rs
+++ b/profile-universal/src/checks/smart_dropout.rs
@@ -18,7 +18,7 @@ fn find_subsequence(haystack: &[u8], needle: &[u8]) -> bool {
 
         Below is the snippet of instructions we expect to see in the fonts:
         
-        ```
+        ```text
         B8 01 FF    PUSHW 0x01FF
         85          SCANCTRL (unconditinally turn on
                               dropout control mode)


### PR DESCRIPTION
We didn't break after a non-numeric/non-period, so "Version 2.000; ttfautohint (v1...." was parsed as `2.0001`. Now we do, and we test it, which means we also have to make testing work. And while doing so, let's also making releases work.