### PR TITLE
Include most of the fixes from gftools-fix

### DIFF
--- a/fontspector-checkapi/src/font.rs
+++ b/fontspector-checkapi/src/font.rs
@@ -28,7 +28,7 @@ use fontations::{
 };
 use itertools::Either;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     error::Error,
     fmt::{Debug, Formatter},
     path::{Path, PathBuf},
@@ -300,7 +300,7 @@ impl TestFont<'_> {
     /// Returns an iterator over the named instances in the font.
     ///
     /// Each item is a tuple of the instance name and a map of axis tag to user coordinate value.
-    pub fn named_instances(&self) -> impl Iterator<Item = (String, HashMap<String, f32>)> + '_ {
+    pub fn named_instances(&self) -> impl Iterator<Item = (String, BTreeMap<String, f32>)> + '_ {
         self.font().named_instances().iter().map(|ni| {
             let instance_name = self
                 .font()

--- a/profile-googlefonts/src/checks/googlefonts/font_names.rs
+++ b/profile-googlefonts/src/checks/googlefonts/font_names.rs
@@ -1,5 +1,6 @@
 use fontations::skrifa::string::StringId;
-use fontspector_checkapi::{prelude::*, testfont, FileTypeConvert, TestFont};
+use fontspector_checkapi::{fixfont, prelude::*, testfont, FileTypeConvert, TestFont};
+use google_fonts_axisregistry::build_name_table;
 use markdown_table::{Heading, MarkdownTable};
 
 use crate::utils::build_expected_font;
@@ -28,7 +29,8 @@ const NAME_IDS: [(StringId, &str); 6] = [
     
     ",
     proposal = "https://github.com/fonttools/fontbakery/pull/3800",
-    title = "Check font names are correct"
+    title = "Check font names are correct",
+    hotfix = fix_font_names,
 )]
 fn font_names(t: &Testable, _context: &Context) -> CheckFnResult {
     let f = testfont!(t);
@@ -89,4 +91,15 @@ fn font_names(t: &Testable, _context: &Context) -> CheckFnResult {
         ));
     }
     return_result(problems)
+}
+
+fn fix_font_names(t: &mut Testable) -> FixFnResult {
+    let f = fixfont!(t);
+    if f.has_axis("MORF") {
+        return Ok(false);
+    }
+    let new_binary =
+        build_name_table(f.font(), None, None, &[], None).map_err(|e| e.to_string())?;
+    t.set(new_binary);
+    Ok(true)
 }

--- a/profile-googlefonts/src/checks/googlefonts/fvar_instances.rs
+++ b/profile-googlefonts/src/checks/googlefonts/fvar_instances.rs
@@ -30,7 +30,12 @@ fn fvar_instances(t: &Testable, _context: &Context) -> CheckFnResult {
     let instances: IndexMap<String, _> = f.named_instances().collect();
     let expected_instances: IndexMap<String, _> = expected_font.named_instances().collect();
     let mut table = vec![];
+    let mut done = IndexSet::new();
     for name in instances.keys().chain(expected_instances.keys()) {
+        if done.contains(name) {
+            continue;
+        }
+        done.insert(name);
         let mut row = IndexMap::new();
         row.insert("Name".to_string(), name.to_string());
         if let Some(font_instance) = instances.get(name) {

--- a/profile-microsoft/src/checks/microsoft/fvar_STAT_axis_ranges.rs
+++ b/profile-microsoft/src/checks/microsoft/fvar_STAT_axis_ranges.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use fontations::skrifa::raw::{tables::stat::AxisValue, TableProvider};
 use fontspector_checkapi::{prelude::*, skip, testfont, FileTypeConvert};
@@ -60,7 +60,7 @@ fn fvar_STAT_axis_ranges(t: &Testable, _context: &Context) -> CheckFnResult {
                     let stat_axis = &stat_axis_tags[axis_index as usize];
                     (stat_axis.to_string(), av.value().to_f32())
                 })
-                .collect::<HashMap<_, _>>();
+                .collect::<BTreeMap<_, _>>();
             if coordinates == stat_coord_set {
                 found_in_format4 = true;
                 break;

--- a/profile-opentype/src/checks/opentype/fvar/regular_coords_correct.rs
+++ b/profile-opentype/src/checks/opentype/fvar/regular_coords_correct.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use fontspector_checkapi::{prelude::*, skip, testfont, FileTypeConvert, TestFont};
 
@@ -9,7 +9,7 @@ const REGULAR_COORDINATE_EXPECTATIONS: [(&str, f32); 4] = [
     ("ital", 0.0),
 ];
 
-fn find_regular(f: TestFont) -> Option<HashMap<String, f32>> {
+fn find_regular(f: TestFont) -> Option<BTreeMap<String, f32>> {
     let mut instance = f.named_instances().find(|(name, _loc)| name == "Regular");
     if instance.is_none() {
         instance = f.named_instances().find(|(name, _loc)| name == "Italic");

--- a/profile-opentype/src/checks/opentype/mac_style.rs
+++ b/profile-opentype/src/checks/opentype/mac_style.rs
@@ -1,5 +1,8 @@
-use fontations::skrifa::raw::{tables::head::MacStyle, TableProvider};
-use fontspector_checkapi::{prelude::*, testfont, FileTypeConvert};
+use fontations::{
+    skrifa::raw::{tables::head::MacStyle, TableProvider},
+    write::from_obj::ToOwnedTable,
+};
+use fontspector_checkapi::{fixfont, prelude::*, testfont, FileTypeConvert};
 
 #[check(
     id = "opentype/mac_style",
@@ -9,6 +12,7 @@ use fontspector_checkapi::{prelude::*, testfont, FileTypeConvert};
         that describe whether a font is bold and/or italic must be coherent with the
         actual style of the font as inferred by its filename.
     ",
+    hotfix = fix_mac_style,
     proposal = "https://github.com/fonttools/fontbakery/issues/4829",  // legacy check
 )]
 fn mac_style(f: &Testable, _context: &Context) -> CheckFnResult {
@@ -44,4 +48,31 @@ fn mac_style(f: &Testable, _context: &Context) -> CheckFnResult {
         ));
     }
     return_result(problems)
+}
+
+fn fix_mac_style(f: &mut Testable) -> FixFnResult {
+    let font = fixfont!(f);
+    let mut head: fontations::write::tables::head::Head = font
+        .font()
+        .head()
+        .map_err(|e| format!("Error getting head table: {}", e))?
+        .to_owned_table();
+
+    let Some(style) = font.style() else {
+        return Ok(false);
+    };
+    let mut bits = head.mac_style;
+    if style == "Bold" || style == "BoldItalic" {
+        bits.insert(MacStyle::BOLD);
+    } else {
+        bits.remove(MacStyle::BOLD);
+    }
+    if style.contains("Italic") {
+        bits.insert(MacStyle::ITALIC);
+    } else {
+        bits.remove(MacStyle::ITALIC);
+    }
+    head.mac_style = bits;
+    f.set(font.rebuild_with_new_tables(&[head])?);
+    Ok(true)
 }

--- a/profile-universal/src/checks/varfont_instances_in_order.rs
+++ b/profile-universal/src/checks/varfont_instances_in_order.rs
@@ -1,6 +1,6 @@
 use fontspector_checkapi::{prelude::*, skip, testfont, FileTypeConvert};
 use itertools::Itertools;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 #[check(
     id = "varfont/instances_in_order",
@@ -17,7 +17,7 @@ fn varfont_instances_in_order(t: &Testable, context: &Context) -> CheckFnResult 
     let f = testfont!(t);
     skip!(!f.has_axis("wght"), "no-wght", "Font has no weight axis");
     let mut problems = vec![];
-    let mut sublists: Vec<Vec<HashMap<String, f32>>> = vec![vec![]];
+    let mut sublists: Vec<Vec<BTreeMap<String, f32>>> = vec![vec![]];
     let coords = f.named_instances().map(|(_name, coords)| coords);
     let mut last_non_wght = None;
 


### PR DESCRIPTION
This should allow us to use `fontspector --profile googlefonts --hotfix` instead of `gftools-fix-font`.