### PR TITLE
Make Fontbakery Python bridge usable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cfaf5e440be44db5413b75b72c2a87c1f8f0627117d110264048f2969b99e9"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -374,9 +374,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bitvec"
@@ -855,7 +855,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.0",
  "crossterm_winapi",
  "derive_more 2.0.1",
  "document-features",
@@ -1152,9 +1152,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -1504,7 +1504,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d228d6de56c90dd7585341f341849441b3490180c62d27133e525eb726809b4"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.0",
  "freetype-sys",
  "libc",
 ]
@@ -1686,7 +1686,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.0",
  "ignore",
  "walkdir",
 ]
@@ -1694,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "google-fonts-axisregistry"
 version = "0.4.13"
-source = "git+https://github.com/googlefonts/axisregistry#7fbe5fdf0c5d4c605d7ec57980b085cbc2e1646b"
+source = "git+https://github.com/googlefonts/axisregistry#8478daeabc1ecab874bc2600b49c1554d51649ff"
 dependencies = [
  "bytes",
  "fontations",
@@ -1734,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "google-fonts-languages"
-version = "0.7.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043b75050ad428f76636bbc88f1006e843bb0d6fd38586803861f41bf08da898"
+checksum = "46660dfb52a0e3d47ae4ab9024a7e1b25ebd1fe695fc9afdfa8c73e94b7cf764"
 dependencies = [
  "bytes",
  "glob",
@@ -2030,7 +2030,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.1",
+ "windows-core 0.61.0",
 ]
 
 [[package]]
@@ -2476,7 +2476,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.0",
  "libc",
  "redox_syscall",
 ]
@@ -2732,7 +2732,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2854,7 +2854,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3506,7 +3506,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -3663,7 +3663,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3676,7 +3676,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -3737,7 +3737,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.0",
  "bytemuck",
  "core_maths",
  "log",
@@ -3805,7 +3805,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3828,7 +3828,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.0",
  "cssparser",
  "derive_more 0.99.20",
  "fxhash",
@@ -4185,7 +4185,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -4950,15 +4950,15 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.1"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
  "windows-implement 0.60.0",
  "windows-interface 0.59.1",
  "windows-link",
- "windows-result 0.3.3",
- "windows-strings 0.4.1",
+ "windows-result 0.3.2",
+ "windows-strings 0.4.0",
 ]
 
 [[package]]
@@ -5017,7 +5017,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.3.3",
+ "windows-result 0.3.2",
  "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
@@ -5033,9 +5033,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
  "windows-link",
 ]
@@ -5051,9 +5051,9 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
 dependencies = [
  "windows-link",
 ]
@@ -5219,7 +5219,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.0",
 ]
 
 [[package]]

--- a/fontspector-checkapi/Cargo.toml
+++ b/fontspector-checkapi/Cargo.toml
@@ -10,6 +10,9 @@ homepage = "https://fonttools.github.io/fontspector"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+python = []
+
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 # Plugin architecture
 pluginator = { workspace = true }

--- a/fontspector-checkapi/src/profile.rs
+++ b/fontspector-checkapi/src/profile.rs
@@ -83,6 +83,11 @@ pub struct Profile {
     /// by providing `WARN_SIZE` and `FAIL_SIZE` values in the profile; the user
     /// can then override these values on the command line.
     configuration_defaults: HashMap<CheckId, HashMap<String, serde_json::Value>>,
+
+    #[cfg(feature = "python")]
+    #[serde(default)]
+    /// Code files to include to register Python-based checks
+    pub check_definitions: Vec<String>,
 }
 
 impl Profile {

--- a/fontspector-cli/Cargo.toml
+++ b/fontspector-cli/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 readme = "../README.md"
 
 [features]
-python = ["dep:fontbakery-bridge"]
+python = ["dep:fontbakery-bridge", "fontspector-checkapi/python"]
 
 [build-dependencies]
 walkdir = "2.5"
@@ -18,9 +18,11 @@ zip = "3"
 quote = "1.0"
 
 [dependencies]
-fontspector-checkapi = { path = "../fontspector-checkapi", features = ["clap"], version = "1.0.0" }
+fontspector-checkapi = { path = "../fontspector-checkapi", features = [
+    "clap",
+], version = "1.0.0" }
 # These profiles are baked-in
-fontbakery-bridge = { path = "../fontbakery-bridge", optional = true, version = "1.0.0", package="fontspector-fontbakery-bridge" }
+fontbakery-bridge = { path = "../fontbakery-bridge", optional = true, version = "1.0.0", package = "fontspector-fontbakery-bridge" }
 profile-universal = { path = "../profile-universal", version = "1.0.0", package = "fontspector-profile-universal" }
 profile-opentype = { path = "../profile-opentype", version = "1.0.0", package = "fontspector-profile-opentype" }
 profile-iso15008 = { path = "../profile-iso15008", version = "1.0.0", package = "fontspector-profile-iso15008" }

--- a/fontspector-cli/src/profiles.rs
+++ b/fontspector-cli/src/profiles.rs
@@ -56,6 +56,7 @@ pub(crate) fn register_and_return_toml_profile(
     name.to_string()
 }
 
+#[allow(unused_variables)]
 pub(crate) fn register_core_profiles(args: &Args, registry: &mut Registry<'static>) {
     #[cfg(feature = "python")]
     if args.use_python {

--- a/fontspector-cli/src/profiles.rs
+++ b/fontspector-cli/src/profiles.rs
@@ -1,0 +1,127 @@
+#[cfg(feature = "python")]
+use fontbakery_bridge::FontbakeryBridge;
+
+use fontspector_checkapi::{Plugin, Profile, Registry};
+use profile_googlefonts::GoogleFonts;
+use profile_iso15008::Iso15008;
+use profile_opentype::OpenType;
+use profile_universal::Universal;
+use std::io::Read;
+use std::path::PathBuf;
+
+use crate::args::Args;
+
+pub(crate) fn register_and_return_toml_profile(
+    args: &Args,
+    registry: &mut Registry<'static>,
+) -> String {
+    // Name should be path basename without extension
+    let path = PathBuf::from(&args.profile);
+    let name = path.file_stem().unwrap_or_default().to_string_lossy();
+    match std::fs::File::open(&path) {
+        Ok(mut file) => {
+            log::info!("Loading profile from file {:?}", name);
+            let mut toml = String::new();
+            if let Err(e) = file.read_to_string(&mut toml) {
+                log::error!("Could not read profile {:}: {:}", name, e);
+                std::process::exit(1);
+            }
+            let profile: Profile = Profile::from_toml(&toml).unwrap_or_else(|e| {
+                log::error!("Could not parse profile {:}: {:}", name, e);
+                std::process::exit(1);
+            });
+
+            #[cfg(feature = "python")]
+            if args.use_python {
+                for python_file in profile.check_definitions.iter() {
+                    if let Err(e) = load_python_profile(registry, python_file, &path) {
+                        log::error!("Could not load python profile {:}: {:}", python_file, e);
+                        std::process::exit(1);
+                    }
+                }
+            }
+
+            registry
+                .register_profile(&name, profile)
+                .unwrap_or_else(|e| {
+                    log::error!("Could not register profile {:}: {:}", name, e);
+                    std::process::exit(1);
+                });
+        }
+        Err(e) => {
+            log::error!("Could not open profile file {:}: {:?}", args.profile, e);
+            std::process::exit(1);
+        }
+    }
+    name.to_string()
+}
+
+pub(crate) fn register_core_profiles(args: &Args, registry: &mut Registry<'static>) {
+    #[cfg(feature = "python")]
+    if args.use_python {
+        // Python implementations first, I want to override them
+        #[allow(clippy::expect_used)] // If this fails, I *want* to panic
+        FontbakeryBridge
+            .register(registry)
+            .expect("Couldn't register fontbakery bridge, fontspector bug");
+    }
+
+    #[allow(clippy::expect_used)] // If this fails, I *want* to panic
+    OpenType
+        .register(registry)
+        .expect("Couldn't register opentype profile, fontspector bug");
+    #[allow(clippy::expect_used)] // If this fails, I *want* to panic
+    Universal
+        .register(registry)
+        .expect("Couldn't register universal profile, fontspector bug");
+
+    #[allow(clippy::expect_used)] // If this fails, I *want* to panic
+    GoogleFonts
+        .register(registry)
+        .expect("Couldn't register googlefonts profile, fontspector bug");
+
+    #[allow(clippy::expect_used)] // If this fails, I *want* to panic
+    Iso15008
+        .register(registry)
+        .expect("Couldn't register iso15008 profile, fontspector bug");
+}
+
+#[cfg(feature = "python")]
+pub fn load_python_profile(
+    registry: &mut Registry<'static>,
+    python_file: &str,
+    relative_to: &PathBuf,
+) -> Result<(), String> {
+    // If the file is relative, make it absolute
+    let python_path = if !PathBuf::from(python_file).is_absolute() {
+        std::fs::canonicalize(relative_to)
+            .map_err(|e| e.to_string())?
+            .parent()
+            .ok_or("Could not get parent directory")?
+            .join(python_file)
+    } else {
+        PathBuf::from(python_file)
+    };
+    log::info!("Loading python profile from file {:?}", python_path);
+    let mut file = std::fs::File::open(&python_path).map_err(|e| {
+        format!(
+            "Could not open python profile file {:?}: {:?}",
+            python_path, e
+        )
+    })?;
+    let mut source = String::new();
+    file.read_to_string(&mut source).map_err(|e| {
+        format!(
+            "Could not read python profile file {:?}: {:?}",
+            python_path, e
+        )
+    })?;
+    // Turn the path into a valid Python module name
+    let module_name = python_file
+        .replace("-", "_")
+        .replace("\\", ".")
+        .replace("/", ".")
+        .replace(".py", "");
+    log::debug!("Module name: {:?}", module_name);
+    fontbakery_bridge::register_python_checks(&module_name, &source, registry)
+}


### PR DESCRIPTION
This allows user profiles to specify `check_definitions` sections (just as with Fontbakery) that point to Python files which are then loaded and registered. And it works!