### PR TITLE
fix(bold_italic_unique_for_nameid1): Allow larger families with same bits

### DIFF
--- a/fontspector-py/tests/test_checks_opentype_os2.py
+++ b/fontspector-py/tests/test_checks_opentype_os2.py
@@ -230,7 +230,8 @@ def test_check_family_bold_italic_unique_for_nameid1(check):
         "CabinCondensed-Regular.ttf",
         "CabinCondensed-Bold.ttf",
     ]
-    
+    font_paths = [os.path.join(base_path, n) for n in font_names]
+    ttFonts = [TTFont(x) for x in font_paths]
     assert_PASS(check(ttFonts))
 
 

--- a/fontspector-py/tests/test_checks_opentype_os2.py
+++ b/fontspector-py/tests/test_checks_opentype_os2.py
@@ -221,6 +221,18 @@ def test_check_family_bold_italic_unique_for_nameid1(check):
     # we should get a failure due to two fonts with both bold & italic set
     message = assert_results_contain(check(ttFonts), FAIL, "unique-fsselection")
 
+    base_path = portable_path("data/test/cabin")
+    font_names = [
+        "Cabin-Regular.ttf",
+        "Cabin-Bold.ttf",
+        "Cabin-Italic.ttf",
+        "Cabin-BoldItalic.ttf",
+        "CabinCondensed-Regular.ttf",
+        "CabinCondensed-Bold.ttf",
+    ]
+    
+    assert_PASS(check(ttFonts))
+
 
 @check_id("opentype/code_pages")
 def test_check_code_pages(check):

--- a/profile-opentype/src/checks/opentype/family/bold_italic_unique_for_nameid1.rs
+++ b/profile-opentype/src/checks/opentype/family/bold_italic_unique_for_nameid1.rs
@@ -20,7 +20,7 @@ use fontspector_checkapi::{prelude::*, FileTypeConvert};
 fn bold_italic_unique_for_nameid1(c: &TestableCollection, _context: &Context) -> CheckFnResult {
     let fonts = TTF.from_collection(c);
     let mut problems = vec![];
-    let mut flags: HashSet<(bool, bool, String)> = HashSet::new();
+    let mut flags: HashSet<(bool, bool, Option<String>)> = HashSet::new();
     let ribbi = fonts.iter().filter(|f| f.is_ribbi());
     for font in ribbi {
         let fsselection = font.get_os2_fsselection()?;
@@ -28,13 +28,13 @@ fn bold_italic_unique_for_nameid1(c: &TestableCollection, _context: &Context) ->
         let val = (
             fsselection.intersects(SelectionFlags::BOLD),
             fsselection.intersects(SelectionFlags::ITALIC),
-            name_id_1[0].clone(), // use the first name id 1 entry
+            name_id_1.first().cloned() // use the first name id 1 entry
         );
         if flags.contains(&val) {
             problems.push(Status::fail(
                 "unique-fsselection",
                 &(format!(
-                    "Font {} has the same selection flags ({}{}{}) as another font ({})",
+                    "Font {} has the same selection flags ({}{}{}) as another font ({:?})",
                     font.filename.to_string_lossy(),
                     if val.0 { "bold" } else { "" },
                     if val.0 && val.1 { " & " } else { "" },

--- a/profile-opentype/src/checks/opentype/family/bold_italic_unique_for_nameid1.rs
+++ b/profile-opentype/src/checks/opentype/family/bold_italic_unique_for_nameid1.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use fontations::skrifa::raw::tables::os2::SelectionFlags;
+use fontations::skrifa::string::StringId;
 use fontspector_checkapi::{prelude::*, FileTypeConvert};
 
 #[check(
@@ -19,23 +20,26 @@ use fontspector_checkapi::{prelude::*, FileTypeConvert};
 fn bold_italic_unique_for_nameid1(c: &TestableCollection, _context: &Context) -> CheckFnResult {
     let fonts = TTF.from_collection(c);
     let mut problems = vec![];
-    let mut flags: HashSet<(bool, bool)> = HashSet::new();
+    let mut flags: HashSet<(bool, bool, String)> = HashSet::new();
     let ribbi = fonts.iter().filter(|f| f.is_ribbi());
     for font in ribbi {
         let fsselection = font.get_os2_fsselection()?;
+        let name_id_1: Vec<_> = font.get_name_entry_strings(StringId::FAMILY_NAME).collect();
         let val = (
             fsselection.intersects(SelectionFlags::BOLD),
             fsselection.intersects(SelectionFlags::ITALIC),
+            name_id_1[0].clone(), // use the first name id 1 entry
         );
         if flags.contains(&val) {
             problems.push(Status::fail(
                 "unique-fsselection",
                 &(format!(
-                    "Font {} has the same selection flags ({}{}{}) as another font",
+                    "Font {} has the same selection flags ({}{}{}) as another font ({})",
                     font.filename.to_string_lossy(),
                     if val.0 { "bold" } else { "" },
                     if val.0 && val.1 { " & " } else { "" },
-                    if val.1 { "italic" } else { "" }
+                    if val.1 { "italic" } else { "" },
+                    val.2,
                 )),
             ));
         } else {

--- a/profile-opentype/src/checks/opentype/family/bold_italic_unique_for_nameid1.rs
+++ b/profile-opentype/src/checks/opentype/family/bold_italic_unique_for_nameid1.rs
@@ -28,7 +28,7 @@ fn bold_italic_unique_for_nameid1(c: &TestableCollection, _context: &Context) ->
         let val = (
             fsselection.intersects(SelectionFlags::BOLD),
             fsselection.intersects(SelectionFlags::ITALIC),
-            name_id_1.first().cloned() // use the first name id 1 entry
+            name_id_1.first().cloned(), // use the first name id 1 entry
         );
         if flags.contains(&val) {
             problems.push(Status::fail(


### PR DESCRIPTION
## Description
bold_italic_unique_for_nameid1 failed in a font family when there are more then one font having the same bits set for Regular, Bold and/or Italic, but it did not take in account the name table id 1. This is why the test fails on families including different widths, eg. Condensed Bold fails, because there is already a 'Normal Bold'.

This PR fixes it.

## Checklist
- [ ] wait for the tests to pass
- [ ] request a review

