### PR TITLE
fix(googlefonts/gasp): add skip for cff fonts

### DIFF
--- a/fontspector-py/tests/test_checks_googlefonts.py
+++ b/fontspector-py/tests/test_checks_googlefonts.py
@@ -3719,3 +3719,13 @@ def test_check_render_own_name(check):
 
     ttFont = TEST_FILE("noto_sans_tamil_supplement/NotoSansTamilSupplement-Regular.ttf")
     assert_results_contain(check(ttFont), FAIL, "render-own-name")
+
+
+@check_id("googlefonts/gasp")
+def test_check_gasp(check):
+    """Check TFF has gasp table."""
+    ttFont = TTFont(TEST_FILE("montserrat/Montserrat-Black.ttf"))
+    assert_PASS(check(ttFont))
+
+    cffFont = TTFont(TEST_FILE("source-sans-pro/OTF/SourceSansPro-Black.otf"))
+    msg = assert_results_contain(check(ttFont), SKIP, "not-ttf")

--- a/fontspector-py/tests/test_checks_googlefonts.py
+++ b/fontspector-py/tests/test_checks_googlefonts.py
@@ -3728,4 +3728,4 @@ def test_check_gasp(check):
     assert_PASS(check(ttFont))
 
     cffFont = TTFont(TEST_FILE("source-sans-pro/OTF/SourceSansPro-Black.otf"))
-    msg = assert_results_contain(check(ttFont), SKIP, "not-ttf")
+    msg = assert_results_contain(check(cffFont), SKIP, "not-ttf")

--- a/profile-googlefonts/src/checks/googlefonts/gasp.rs
+++ b/profile-googlefonts/src/checks/googlefonts/gasp.rs
@@ -3,7 +3,7 @@ use fontations::{
     types::Tag,
     write::FontBuilder,
 };
-use fontspector_checkapi::{prelude::*, testfont, FileTypeConvert};
+use fontspector_checkapi::{prelude::*, skip, testfont, FileTypeConvert};
 use tabled::builder::Builder;
 
 const NON_HINTING_MESSAGE: &str =  "If you are dealing with an unhinted font, it can be fixed by running the fonts through the command 'gftools fix-nonhinting'\nGFTools is available at https://pypi.org/project/gftools/";
@@ -49,6 +49,10 @@ set to optimize rendering?"
 )]
 fn gasp(t: &Testable, _context: &Context) -> CheckFnResult {
     let f = testfont!(t);
+    skip!(f.has_table(b"CFF ") || f.has_table(b"CFF2"),
+        "not-ttf",
+        "Skip gasp table test, because CFF font."
+    );
     let mut problems = vec![];
     if !f.has_table(b"gasp") {
         return Ok(Status::just_one_fail(


### PR DESCRIPTION
## Description
Fixes #283

## Checklist
- [ ] wait for the tests to pass
- [ ] request a review

