### PR TITLE
chore: Revert "fix(deps): update dependency harfbuzzjs to v0.4.8 (#360)"

### DIFF
--- a/fontspector-web/www/package-lock.json
+++ b/fontspector-web/www/package-lock.json
@@ -1828,10 +1828,9 @@
       "license": "MIT"
     },
     "node_modules/harfbuzzjs": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/harfbuzzjs/-/harfbuzzjs-0.4.8.tgz",
-      "integrity": "sha512-eo2DEe+xMev6szwGZETogFQ1Kx4G8vK4OSFSmbqEYKXrN89xN7LpxI9a9GI5G1rzPTBhM+iBUPZwhJ32wU/e1g==",
-      "license": "MIT"
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/harfbuzzjs/-/harfbuzzjs-0.4.7.tgz",
+      "integrity": "sha512-fGrMB7gk+x1ye++cN+OgDnHLLz8wg6aW26VPb8Q14V6XeZKGC0BCALe+ZEnwASU/b+YprBnRTELMJAlwy9jrLw=="
     },
     "node_modules/has-flag": {
       "version": "4.0.0",


### PR DESCRIPTION
This reverts commit c4e876ceb6ee52f6a53c45c25be52c648d5d49cb. Fixes #392
