### PR TITLE
Update Fontwerk profile

### DIFF
--- a/profile-fontwerk/src/checks/fontwerk/glyph_coverage.rs
+++ b/profile-fontwerk/src/checks/fontwerk/glyph_coverage.rs
@@ -40,7 +40,7 @@ const FW_LAT_STD_ENCODED_GLYPHS: [u32; 414] = [
     0x0303, 0x0304, 0x0326, 0x0327, 0x0328, 0x00A8, 0x02D9, 0x0060, 0x00B4, 0x02DD, 0x02C6, 0x02C7,
     0x02D8, 0x02DA, 0x02DC, 0x00AF, 0x00B8, 0x02DB,
 ];
-const FW_LAT_STD_UNENCODED_GLYPHS: &[[&str; 2]; 48] = &[
+const FW_LAT_STD_UNENCODED_GLYPHS: &[[&str; 2]; 11] = &[
     // [prefered name, alternative name]
     [".notdef", ".notdef"],
     ["zero.tf", "uni0030.tf"],
@@ -53,43 +53,6 @@ const FW_LAT_STD_UNENCODED_GLYPHS: &[[&str; 2]; 48] = &[
     ["seven.tf", "uni0037.tf"],
     ["eight.tf", "uni0038.tf"],
     ["nine.tf", "uni0039.tf"],
-    ["leftanglebracket-math.case", "uni27E8.case"],
-    ["rightanglebracket-math.case", "uni27E9.case"],
-    ["hyphen.case", "uni002D.case"],
-    ["endash.case", "uni2013.case"],
-    ["emdash.case", "uni2014.case"],
-    ["figuredash.case", "uni2012.case"],
-    ["hyphentwo.case", "uni2010.case"],
-    ["nonbreakinghyphen.case", "uni2011.case"],
-    ["parenleft.case", "uni0028.case"],
-    ["parenright.case", "uni0029.case"],
-    ["braceleft.case", "uni007B.case"],
-    ["braceright.case", "uni007D.case"],
-    ["bracketleft.case", "uni005B.case"],
-    ["bracketright.case", "uni005D.case"],
-    ["guillemetleft.case", "guillemotleft.case"],
-    ["guillemetright.case", "guillemotright.case"],
-    ["guilsinglleft.case", "uni2039.case"],
-    ["guilsinglright.case", "uni203A.case"],
-    ["colon.case", "uni003A.case"],
-    ["exclamdown.case", "uni00A1.case"],
-    ["questiondown.case", "uni00BF.case"],
-    ["periodcentered.case", "uni00B7.case"],
-    ["bullet.case", "uni2022.case"],
-    ["slash.case", "uni002F.case"],
-    ["backslash.case", "uni005C.case"],
-    ["at.case", "uni0040.case"],
-    ["dieresiscomb.case", "uni0308.case"],
-    ["dotaccentcomb.case", "uni0307.case"],
-    ["gravecomb.case", "uni0300.case"],
-    ["acutecomb.case", "uni0301.case"],
-    ["hungarumlautcomb.case", "uni030B.case"],
-    ["circumflexcomb.case", "uni0302.case"],
-    ["caroncomb.case", "uni030C.case"],
-    ["brevecomb.case", "uni0306.case"],
-    ["ringcomb.case", "uni030A.case"],
-    ["tildecomb.case", "uni0303.case"],
-    ["macroncomb.case", "uni0304.case"],
 ];
 
 #[check(
@@ -179,7 +142,7 @@ mod tests {
             .next()
             .unwrap();
 
-        let expected_message = "This font is missing required glyphs:\n\n[\"uniFEFF\", \"uni2060\", \"uni27E8\", \"uni27E9\", \"uni2011\", \"uni20BF\", \"uni2052\", \"uni22C5\", \"uni2117\", \"uniFFFD\", \"leftanglebracket-math.case\", \"rightanglebracket-math.case\", \"figuredash.case\", \"hyphentwo.case\", \"nonbreakinghyphen.case\", \"colon.case\", \"exclamdown.case\", \"questiondown.case\", \"ringcomb.case\"]";
+        let expected_message = "This font is missing required glyphs:\n\n[\"uniFEFF\", \"uni2060\", \"uni27E8\", \"uni27E9\", \"uni2011\", \"uni20BF\", \"uni2052\", \"uni22C5\", \"uni2117\", \"uniFFFD\"]";
         assert_eq!(result.message, Some(expected_message.to_string()));
     }
 }

--- a/profile-fontwerk/src/checks/fontwerk/mod.rs
+++ b/profile-fontwerk/src/checks/fontwerk/mod.rs
@@ -7,3 +7,5 @@ mod fstype;
 pub use fstype::fstype;
 mod glyph_coverage;
 pub use glyph_coverage::glyph_coverage;
+mod weightclass;
+pub use weightclass::weightclass;

--- a/profile-fontwerk/src/checks/fontwerk/weightclass.rs
+++ b/profile-fontwerk/src/checks/fontwerk/weightclass.rs
@@ -1,0 +1,154 @@
+use fontations::skrifa::raw::TableProvider;
+use fontspector_checkapi::{prelude::*, testfont, FileTypeConvert};
+
+fn get_expected_weight_name(weight_class: u16) -> Option<&'static [&'static str]> {
+    match weight_class {
+        1..=99 => Some(&["Hairline", "Hair"]),
+        100 => Some(&["Thin"]),
+        200 => Some(&["XLight", "ExtraLight"]),
+        300 => Some(&["Light"]),
+        400 => Some(&["Regular"]),
+        500 => Some(&["Medium"]),
+        600 => Some(&["SemiBold"]),
+        700 => Some(&["Bold"]),
+        800 => Some(&["XBold", "ExtraBold"]),
+        900 => Some(&["Black"]),
+        901..=1000 => Some(&["XBlack", "ExtraBlack"]),
+        _ => None,
+    }
+}
+
+#[check(
+    id = "fontwerk/weightclass",
+    rationale = "
+        Fontwerk expects the following OS/2 usWeightClass values:
+
+        Hairline 1-99
+        Thin 100
+        XLight 200
+        Light 300
+        Regular 400
+        Medium 500
+        SemiBold 600
+        Bold 700
+        XBold 800
+        Black 900
+        XBlack 901-1000
+    ",
+    proposal = "https://github.com/fonttools/fontbakery/issues/4829",
+    title = "Check the OS/2 usWeightClass is appropriate for the font's best SubFamily name."
+)]
+fn weightclass(t: &Testable, _context: &Context) -> CheckFnResult {
+    let f = testfont!(t);
+    let value = f.font().os2()?.us_weight_class();
+    let style_name = f.best_subfamilyname().unwrap_or("Regular".to_string());
+    let style_name_parts = style_name.split(' ').collect::<Vec<_>>();
+    let expected_weight_names = get_expected_weight_name(value);
+
+    if let Some(expected_names) = expected_weight_names {
+        for weight_name in expected_names {
+            if style_name_parts.contains(weight_name) {
+                return Ok(Status::just_one_pass());
+            }
+        }
+        Ok(Status::just_one_fail(
+            "bad-weight-class-value", 
+            &format!(
+                "For OS/2 usWeightClass {value} we expect {expected_names:?}, but got '{style_name}'. Either usWeightClass is wrong or style name. Please investigate."
+            )
+        ))
+    } else {
+        Ok(Status::just_one_fail(
+            "bad-weight-class-value",
+            &format!(
+                "OS/2 usWeightClass {value} does not match fontwerk specifications. We expect: Hairline 1..=99, Thin 100, XLight 200, Light 300, Regular 400, Medium 500, SemiBold 600, Bold 700, XBold 800, Black 900, XBlack 901..=1000."
+            )
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+    use fontations::write::{
+        tables::maxp::Maxp,
+        tables::name::{Name, NameRecord},
+        tables::os2::Os2,
+        types::NameId,
+        FontBuilder,
+    };
+    use fontspector_checkapi::{Context, Testable};
+
+    #[test]
+    fn test_weightclass() {
+        let weight_tests = [
+            (50, "Hairline", None),
+            (400, "Hairline", Some("For OS/2 usWeightClass 400 we expect [\"Regular\"], but got 'Hairline'. Either usWeightClass is wrong or style name. Please investigate.".to_string())),
+            (1000, "XBlack", None),
+            (400, "XBlack", Some("For OS/2 usWeightClass 400 we expect [\"Regular\"], but got 'XBlack'. Either usWeightClass is wrong or style name. Please investigate.".to_string())),
+            (400, "Regular", None),
+            (333, "Regular", Some("OS/2 usWeightClass 333 does not match fontwerk specifications. We expect: Hairline 1..=99, Thin 100, XLight 200, Light 300, Regular 400, Medium 500, SemiBold 600, Bold 700, XBold 800, Black 900, XBlack 901..=1000.".to_string())),
+            (900, "Condensed Black", None),
+            (600, "XXCond SemiBold Italic", None),
+            (500, "XXCond SemiBold Italic", Some("For OS/2 usWeightClass 500 we expect [\"Medium\"], but got 'XXCond SemiBold Italic'. Either usWeightClass is wrong or style name. Please investigate.".to_string())),
+            (50, "XXWide Hair Italic", None),
+            (100, "Whatever Thin", None),
+            (200, "ExtraLight", None),
+            (200, "XLight", None),
+            (300, "Light", None),
+            (300, "XLight", Some("For OS/2 usWeightClass 300 we expect [\"Light\"], but got 'XLight'. Either usWeightClass is wrong or style name. Please investigate.".to_string())),
+            (600, "SemiBold", None),
+            (600, "DemiBold", Some("For OS/2 usWeightClass 600 we expect [\"SemiBold\"], but got 'DemiBold'. Either usWeightClass is wrong or style name. Please investigate.".to_string())),
+            (700, "Bold", None),
+            (700, "XBold", Some("For OS/2 usWeightClass 700 we expect [\"Bold\"], but got 'XBold'. Either usWeightClass is wrong or style name. Please investigate.".to_string())),
+            (800, "XBold", None),
+            (800, "Black", Some("For OS/2 usWeightClass 800 we expect [\"XBold\", \"ExtraBold\"], but got 'Black'. Either usWeightClass is wrong or style name. Please investigate.".to_string())),
+            (900, "Black", None),
+            (1000, "Black", Some("For OS/2 usWeightClass 1000 we expect [\"XBlack\", \"ExtraBlack\"], but got 'Black'. Either usWeightClass is wrong or style name. Please investigate.".to_string())),
+            (950, "XBlack", None),
+            (1000, "XBlack", None),
+            ];
+        for (weight_class_value, style_name, expected_result) in weight_tests {
+            let mut font_builder = FontBuilder::new();
+            let maxp = Maxp::default();
+            font_builder.add_table(&maxp).unwrap();
+
+            let mut os2: Os2 = Os2::default();
+            os2.us_weight_class = weight_class_value;
+            font_builder.add_table(&os2).unwrap();
+
+            let mut name: Name = Name::default();
+            let mut new_records = Vec::new();
+            // english default 3/1/1033
+            let name_rec_fam = NameRecord::new(
+                3,
+                1,
+                1033,
+                NameId::new(16),
+                "A Family Name".to_string().into(),
+            );
+            new_records.push(name_rec_fam);
+            let name_rec_sub =
+                NameRecord::new(3, 1, 1033, NameId::new(17), style_name.to_string().into());
+            new_records.push(name_rec_sub);
+            new_records.sort();
+            name.name_record = new_records;
+            font_builder.add_table(&name).unwrap();
+
+            let font = font_builder.build();
+
+            let testable = Testable::new_with_contents("demo.otf", font);
+            let context = Context {
+                ..Default::default()
+            };
+            let result = weightclass_impl(&testable, &context)
+                .unwrap()
+                .next()
+                .unwrap();
+
+            assert_eq!(result.message, expected_result);
+        }
+    }
+}

--- a/profile-fontwerk/src/lib.rs
+++ b/profile-fontwerk/src/lib.rs
@@ -31,6 +31,7 @@ impl fontspector_checkapi::Plugin for Fontwerk {
             .exclude_check("googlefonts/version_bump")
             .exclude_check("googlefonts/font_names")
             .exclude_check("googlefonts/varfont/has_HVAR")
+            .exclude_check("googlefonts/weightclass")
             .exclude_check("control_chars")
             .exclude_check("fontdata_namecheck")
             .include_profile("opentype")
@@ -40,7 +41,7 @@ impl fontspector_checkapi::Plugin for Fontwerk {
             .add_and_register_check(checks::fontwerk::required_name_ids)
             .add_and_register_check(checks::fontwerk::fstype)
             .add_and_register_check(checks::fontwerk::glyph_coverage)
-            //.add_and_register_check(checks::fontwerk::vendor_id)
+            .add_and_register_check(checks::fontwerk::weightclass)
             // TODO: implement other Fontwerk checks
             // .add_and_register_check("fontwerk/names_match_default_fvar")
             .with_configuration_defaults(


### PR DESCRIPTION
## Description
Relates to issue https://github.com/fontwerk/specifications/issues/3

- We decided to not have nay .case glyphs within the minimum character set.
- All fonts should have nice usWeightClass values, no 250 cut for Windows apps like PPT.

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

