### PR TITLE
refactor(fontwerk/names.rs): replace get_name_PEL_codes and get_name_entry_string

### DIFF
--- a/profile-fontwerk/src/checks/fontwerk/names.rs
+++ b/profile-fontwerk/src/checks/fontwerk/names.rs
@@ -1,12 +1,9 @@
-use fontations::{
-    read::{tables::name::NameString, TableProvider},
-    skrifa::{font::FontRef, string::StringId},
+use fontations::skrifa::string::StringId;
+use fontspector_checkapi::{
+    get_name_entry_string, get_name_platform_tuples, prelude::*, skip, testfont, FileTypeConvert,
+    PlatformSelector,
 };
-use fontspector_checkapi::{prelude::*, skip, testfont, FileTypeConvert};
-use std::{
-    collections::{HashMap, HashSet},
-    vec,
-};
+use std::{collections::HashMap, vec};
 
 #[check(
     id = "fontwerk/name_entries",
@@ -117,15 +114,17 @@ fn required_name_ids(t: &Testable, context: &Context) -> CheckFnResult {
         return Ok(Status::just_one_fail("lacks-table", "No name table."));
     }
     let mut bad_names: Vec<String> = vec![];
-
-    let name_PEL_codes = get_name_PEL_codes(font.font());
-    for code in name_PEL_codes {
+    let platform_tuples = get_name_platform_tuples(font.font());
+    for platform_tuple in platform_tuples {
         let mut missing_name_ids: Vec<_> = vec![];
         for id in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 25] {
             let name_id = StringId::from(id);
-            if let Some(_name_string) =
-                get_name_entry_string(&font.font(), code.0, code.1, code.2, name_id)
-            {
+            let selector = PlatformSelector {
+                platform_id: platform_tuple.0,
+                encoding_id: platform_tuple.1,
+                language_id: platform_tuple.2,
+            };
+            if let Some(_name_string) = get_name_entry_string(&font.font(), selector, name_id) {
                 continue;
             } else {
                 if id == 25 && !font.is_variable_font() {
@@ -137,7 +136,7 @@ fn required_name_ids(t: &Testable, context: &Context) -> CheckFnResult {
         }
         if !missing_name_ids.is_empty() {
             bad_names.push(format!(
-                "Missing required name IDs {missing_name_ids:?} for {code:?}.",
+                "Missing required name IDs {missing_name_ids:?} for {platform_tuple:?}.",
             ));
         }
     }
@@ -183,8 +182,8 @@ fn name_consistency(t: &Testable, context: &Context) -> CheckFnResult {
         ),
     ];
 
-    let name_PEL_codes = get_name_PEL_codes(font.font());
-    for code in name_PEL_codes {
+    let platform_tuples = get_name_platform_tuples(font.font());
+    for platform_tuple in platform_tuples {
         let mut name_strings: Vec<(String, String)> = vec![];
         for (i, name_id_pair) in name_ids.iter().enumerate() {
             let mut full_name = String::new();
@@ -194,9 +193,12 @@ fn name_consistency(t: &Testable, context: &Context) -> CheckFnResult {
                 id_pair.push(sub_name_id);
             }
             for name_id in id_pair.iter() {
-                if let Some(name_string) =
-                    get_name_entry_string(&font.font(), code.0, code.1, code.2, *name_id)
-                {
+                let selector = PlatformSelector {
+                    platform_id: platform_tuple.0,
+                    encoding_id: platform_tuple.1,
+                    language_id: platform_tuple.2,
+                };
+                if let Some(name_string) = get_name_entry_string(&font.font(), selector, *name_id) {
                     pair.push(true);
                     full_name.push_str(&name_string.to_string());
                     full_name.push(' ');
@@ -229,7 +231,7 @@ fn name_consistency(t: &Testable, context: &Context) -> CheckFnResult {
                 if first.0 != name.0 {
                     bad_names.push(format!(
                         "Inconsistent names {:?}: {} ({}) != {} ({})",
-                        code, first.0, first.1, name.0, name.1
+                        platform_tuple, first.0, first.1, name.0, name.1
                     ));
                 }
             }
@@ -246,34 +248,6 @@ fn name_consistency(t: &Testable, context: &Context) -> CheckFnResult {
                 bullet_list(context, bad_names)
             ),
         )
-    })
-}
-
-/// Get a string from the font's name table by platform_id, encoding_id, language_id and name_id
-fn get_name_entry_string<'a>(
-    font: &'a FontRef,
-    platform_id: u16,
-    encoding_id: u16,
-    language_id: u16,
-    name_id: StringId,
-) -> Option<NameString<'a>> {
-    let name = font.name().ok();
-    let mut records = name
-        .as_ref()
-        .map(|name| name.name_record().iter())
-        .unwrap_or([].iter());
-    records.find_map(|record| {
-        if record.platform_id() == platform_id
-            && record.encoding_id() == encoding_id
-            && record.language_id() == language_id
-            && record.name_id() == name_id
-        {
-            // Use ? to extract the TableRef before calling string_data()
-            let name_table = name.as_ref()?;
-            record.string(name_table.string_data()).ok()
-        } else {
-            None
-        }
     })
 }
 
@@ -319,24 +293,6 @@ fn get_string_id_from_string(name_id_string: &str) -> Option<StringId> {
     registered_name_ids.get(name_id_string).copied()
 }
 
-fn get_name_PEL_codes(font: FontRef) -> Vec<(u16, u16, u16)> {
-    let name_table = font.name().ok();
-
-    let mut codes_vec = vec![];
-    if let Some(name_table) = name_table {
-        for rec in name_table.name_record().iter() {
-            let code = (rec.platform_id(), rec.encoding_id(), rec.language_id());
-            codes_vec.push(code);
-        }
-    }
-    // make set of codes_vec
-    let unique_codes: HashSet<(u16, u16, u16)> = codes_vec.into_iter().collect();
-
-    let mut unique_codes: Vec<(u16, u16, u16)> = unique_codes.into_iter().collect();
-    unique_codes.sort();
-    unique_codes
-}
-
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
@@ -356,17 +312,6 @@ mod tests {
     fn test_get_name_ids_from_string() {
         let string_id = get_string_id_from_string("TYPOGRAPHIC_FAMILY_NAME");
         assert_eq!(string_id.unwrap(), StringId::TYPOGRAPHIC_FAMILY_NAME);
-    }
-
-    #[test]
-    fn test_get_name_PEL_codes() {
-        let contents = include_bytes!(
-            "../../../../fontspector-py/data/test/montserrat/Montserrat-Regular.ttf"
-        );
-        let font = FontRef::new(contents).expect("Failed to create FontRef from contents");
-        let expected_codes = vec![(1, 0, 0), (3, 1, 1033)];
-        let name_PEL_codes = get_name_PEL_codes(font);
-        assert_eq!(name_PEL_codes, expected_codes);
     }
 
     #[test]
@@ -533,7 +478,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let expected_message = "The following issues have been found:\n\n* Missing required name IDs [7, 10, 16, 17] for (1, 0, 0).\n* Missing required name IDs [7, 10, 16, 17] for (3, 1, 1033).";
+        let expected_message = "The following issues have been found:\n\n* Missing required name IDs [7, 10, 16, 17] for (3, 1, 1033).\n* Missing required name IDs [7, 10, 16, 17] for (1, 0, 0).";
         assert_eq!(result.message, Some(expected_message.to_string()));
     }
 }


### PR DESCRIPTION
+ fix uniitest (because of different sorting of platform _tuples)

## Description
Relates to issue #474 

Refactor code by replacing `get_name_PEL_codes` and `get_name_entry_string` with general function stored in fontspector_checkapi (which we recently added, that why this is a follow-up)

This is a draft PR, because I am wondering if we would like to move "fontwerk/name_entries" to universal. If not, this PR is ready for review.

