### PR TITLE
docs: fix documentation on overrides

### DIFF
--- a/USING.md
+++ b/USING.md
@@ -130,12 +130,13 @@ which is reported with the result. For example, when the
 `mandatory_glyphs` check reports that the `.notdef`
 glyph does not contain any outlines, it reports the message ID `empty` and
 a `WARN` status. To replace this status and have it return a `FAIL` instead,
-place this in the configuration file (if you are using YAML format):
+place this in the configuration file (if you are using the TOML format):
 
-```
-overrides:
-  mandatory_glyphs:
-    empty: FAIL
+```toml
+[[overrides]]
+code = "empty"
+status = "FAIL"
+reason = "Because I think this would be really bad, actually"
 ```
 
 ## Providing options to checks


### PR DESCRIPTION
## Description

Translating the YAML into TOML does not work currently, I guess it's ported from the old Fontbakery or something?

In any case, I've updated the docs to show the correct schema, and in TOML (is YAML even supported by fontspector?)

One thing to note that I thought was strange, but this new schema doesn't let you specify the check ID to do the override for, only the message code (note the disappearance of `mandatory_glyphs` in the example). I guess in theory if message codes were entirely unique it wouldn't be an issue, but AFAIK we don't enforce that and some message codes are quite vague without their check ID as context. I could open an issue for this?

## Checklist
- [ ] update `CHANGELOG.md` (is this relevant for a non-code change? These Markdown docs aren't published to crates.io, are they?)
- [ ] wait for the tests to pass
- [ ] request a review

