### PR TITLE
fix(googlefonts/metadata/primary_script): Allow Hani as synonym for Hans/Hant

### DIFF
--- a/profile-googlefonts/src/checks/googlefonts/metadata/primary_script.rs
+++ b/profile-googlefonts/src/checks/googlefonts/metadata/primary_script.rs
@@ -119,8 +119,8 @@ mod tests {
     #[allow(clippy::expect_used)]
     #[test]
     fn test_check_primary_script() {
-        let testable = test_able("resources/cjk/NotoSansJP[wght].ttf");
-        let md = test_able("resources/cjk/METADATA.pb");
+        let testable = test_able("cjk/NotoSansJP[wght].ttf");
+        let md = test_able("cjk/METADATA.pb");
         let results = run_check_with_config(
             primary_script,
             fontspector_checkapi::TestableType::Collection(&TestableCollection::from_testables(

--- a/resources/test/cjk/METADATA.pb
+++ b/resources/test/cjk/METADATA.pb
@@ -1,0 +1,34 @@
+name: "Noto Sans JP"
+designer: "Google"
+license: "OFL"
+category: "SANS_SERIF"
+date_added: "2015-01-29"
+fonts {
+  name: "Noto Sans JP"
+  style: "normal"
+  weight: 400
+  filename: "NotoSansJP[wght].ttf"
+  post_script_name: "NotoSansJP-Thin"
+  full_name: "Noto Sans JP Thin"
+  copyright: "(c) 2014-2021 Adobe (http://www.adobe.com/), with Reserved Font Name 'Source'."
+}
+subsets: "cyrillic"
+subsets: "japanese"
+subsets: "latin"
+subsets: "latin-ext"
+subsets: "menu"
+subsets: "vietnamese"
+axes {
+  tag: "wght"
+  min_value: 100.0
+  max_value: 900.0
+}
+is_noto: true
+languages: "ain_Kana"  # Ainu
+languages: "ja_Jpan"  # Japanese
+languages: "ja_Hira"  # Japanese, Hiragana
+languages: "ja_Kana"  # Japanese, Katakana
+languages: "ryu_Jpan"  # Central Okinawan, Japanese
+languages: "ryu_Kana"  # Central Okinawan
+display_name: "Noto Sans Japanese"
+primary_script: "Jpan"


### PR DESCRIPTION
fixes #590