### PR TITLE
fix(googlefonts): Check full names match against METADATA for varfonts

### DIFF
--- a/profile-googlefonts/src/checks/googlefonts/color_fonts.rs
+++ b/profile-googlefonts/src/checks/googlefonts/color_fonts.rs
@@ -57,10 +57,10 @@ fn color_fonts(t: &Testable, _context: &Context) -> CheckFnResult {
 #[cfg(test)]
 mod tests {
     use super::color_fonts;
-    use fontspector_checkapi::codetesting::{
-        add_table, assert_pass, assert_results_contain, run_check, test_able,
+    use fontspector_checkapi::{
+        codetesting::{add_table, assert_pass, assert_results_contain, run_check, test_able},
+        StatusCode,
     };
-    use fontspector_checkapi::StatusCode;
 
     #[test]
     fn test_color_fonts_colrv1_no_svg_static() {

--- a/profile-googlefonts/src/checks/googlefonts/metadata/consistent_with_fonts.rs
+++ b/profile-googlefonts/src/checks/googlefonts/metadata/consistent_with_fonts.rs
@@ -129,18 +129,27 @@ fn consistent_with_fonts(c: &TestableCollection, _context: &Context) -> CheckFnR
                 ));
             }
         }
-        if font.is_ribbi() && !font.is_variable_font() {
-            for family_name in font.get_name_entry_strings(StringId::FAMILY_NAME) {
-                if proto.name() != family_name {
-                    problems.push(Status::fail(
+        let must_match = font.is_ribbi() && !font.is_variable_font();
+        for family_name in font.get_name_entry_strings(StringId::FAMILY_NAME) {
+            if proto.name() != family_name {
+                let problem = if must_match {
+                    Status::fail(
                     "familyname-mismatch",
                     &format!(
                     "METADATA.pb family name field \"{}\" does not match correct family name \"{}\".",
                     proto.name(),
                     family_name
-                ),
-                ));
-                }
+                ))
+                } else {
+                    Status::warn(
+                        "familyname-mismatch",
+                        &format!(
+                        "METADATA.pb family name field \"{}\" does not match correct family name \"{}\". This is a warning because the font is not a non-variable RIBBI.",
+                        proto.name(),
+                        family_name
+                    ) )
+                };
+                problems.push(problem);
             }
         }
 

--- a/profile-googlefonts/src/checks/googlefonts/metadata/primary_script.rs
+++ b/profile-googlefonts/src/checks/googlefonts/metadata/primary_script.rs
@@ -109,10 +109,10 @@ fn primary_script(c: &TestableCollection, context: &Context) -> CheckFnResult {
 
 #[cfg(test)]
 mod tests {
-    use fontspector_checkapi::codetesting::{
-        assert_pass, assert_results_contain, run_check_with_config, test_able,
+    use fontspector_checkapi::{
+        codetesting::{assert_pass, assert_results_contain, run_check_with_config, test_able},
+        StatusCode, Testable,
     };
-    use fontspector_checkapi::{StatusCode, Testable};
 
     use fontspector_checkapi::TestableCollection;
     use std::collections::HashMap;

--- a/profile-googlefonts/src/checks/googlefonts/metadata/validate.rs
+++ b/profile-googlefonts/src/checks/googlefonts/metadata/validate.rs
@@ -295,11 +295,10 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::*;
-    use fontspector_checkapi::codetesting::{
-        assert_pass, assert_results_contain, run_check, test_able,
+    use fontspector_checkapi::{
+        codetesting::{assert_pass, assert_results_contain, run_check, test_able},
+        StatusCode, Testable,
     };
-    use fontspector_checkapi::StatusCode;
-    use fontspector_checkapi::Testable;
 
     fn replace_in_metadata(path: &str, old: &str, new: &str) -> Testable {
         let mdpb = test_able(path);

--- a/profile-googlefonts/src/checks/outline/alignment_miss.rs
+++ b/profile-googlefonts/src/checks/outline/alignment_miss.rs
@@ -170,10 +170,12 @@ fn alignment_miss(t: &Testable, context: &Context) -> CheckFnResult {
 mod tests {
     #![allow(clippy::unwrap_used)]
 
-    use fontspector_checkapi::codetesting::{
-        assert_messages_contain, assert_pass, assert_results_contain, run_check, test_able,
+    use fontspector_checkapi::{
+        codetesting::{
+            assert_messages_contain, assert_pass, assert_results_contain, run_check, test_able,
+        },
+        StatusCode,
     };
-    use fontspector_checkapi::StatusCode;
 
     #[test]
     fn test_outline_alignment_miss() {
@@ -196,8 +198,10 @@ mod tests {
 
     #[test]
     fn test_outline_alignment_miss_os2_low_version() {
-        use fontations::skrifa::raw::TableProvider;
-        use fontations::write::{from_obj::ToOwnedTable, FontBuilder};
+        use fontations::{
+            skrifa::raw::TableProvider,
+            write::{from_obj::ToOwnedTable, FontBuilder},
+        };
         use fontspector_checkapi::FileTypeConvert;
 
         let mut testable = test_able("merriweather/Merriweather-Regular.ttf");

--- a/profile-universal/src/checks/case_mapping.rs
+++ b/profile-universal/src/checks/case_mapping.rs
@@ -119,10 +119,10 @@ fn case_mapping(t: &Testable, context: &Context) -> CheckFnResult {
 #[cfg(test)]
 mod tests {
     use super::case_mapping;
-    use fontspector_checkapi::codetesting::{
-        assert_pass, assert_results_contain, run_check, test_able,
+    use fontspector_checkapi::{
+        codetesting::{assert_pass, assert_results_contain, run_check, test_able},
+        StatusCode,
     };
-    use fontspector_checkapi::StatusCode;
 
     #[test]
     fn test_case_mapping_fail() {

--- a/profile-universal/src/checks/empty_glyph_on_gid1_for_colrv0.rs
+++ b/profile-universal/src/checks/empty_glyph_on_gid1_for_colrv0.rs
@@ -34,10 +34,10 @@ fn empty_glyph_on_gid1_for_colrv0(t: &Testable, _context: &Context) -> CheckFnRe
 #[cfg(test)]
 mod tests {
     use super::empty_glyph_on_gid1_for_colrv0;
-    use fontspector_checkapi::codetesting::{
-        assert_pass, assert_results_contain, run_check, test_able,
+    use fontspector_checkapi::{
+        codetesting::{assert_pass, assert_results_contain, run_check, test_able},
+        StatusCode,
     };
-    use fontspector_checkapi::StatusCode;
 
     #[test]
     fn test_empty_glyph_gid1_not_empty() {

--- a/profile-universal/src/checks/family_vertical_metrics.rs
+++ b/profile-universal/src/checks/family_vertical_metrics.rs
@@ -106,8 +106,10 @@ mod tests {
     use std::collections::HashMap;
 
     use super::family_vertical_metrics;
-    use fontspector_checkapi::codetesting::{assert_pass, run_check_with_config, test_able};
-    use fontspector_checkapi::{TestableCollection, TestableType};
+    use fontspector_checkapi::{
+        codetesting::{assert_pass, run_check_with_config, test_able},
+        TestableCollection, TestableType,
+    };
 
     #[test]
     fn test_family_vertical_metrics_pass() {

--- a/profile-universal/src/checks/family_win_ascent_and_descent.rs
+++ b/profile-universal/src/checks/family_win_ascent_and_descent.rs
@@ -162,10 +162,10 @@ mod tests {
     use std::collections::HashMap;
 
     use super::family_win_ascent_and_descent;
-    use fontspector_checkapi::codetesting::{
-        assert_results_contain, run_check_with_config, test_able,
+    use fontspector_checkapi::{
+        codetesting::{assert_results_contain, run_check_with_config, test_able},
+        StatusCode, TestableCollection, TestableType,
     };
-    use fontspector_checkapi::{StatusCode, TestableCollection, TestableType};
 
     #[test]
     fn test_family_win_ascent_descent_fail() {

--- a/profile-universal/src/checks/mandatory_avar_table.rs
+++ b/profile-universal/src/checks/mandatory_avar_table.rs
@@ -37,10 +37,10 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::mandatory_avar_table;
-    use fontspector_checkapi::codetesting::{
-        assert_pass, assert_results_contain, remove_table, run_check, test_able,
+    use fontspector_checkapi::{
+        codetesting::{assert_pass, assert_results_contain, remove_table, run_check, test_able},
+        StatusCode,
     };
-    use fontspector_checkapi::StatusCode;
 
     #[test]
     fn test_mandatory_avar_pass() {

--- a/profile-universal/src/checks/name/char_restrictions.rs
+++ b/profile-universal/src/checks/name/char_restrictions.rs
@@ -105,10 +105,10 @@ mod tests {
 
     use super::char_restrictions;
     use fontations::skrifa::raw::types::NameId;
-    use fontspector_checkapi::codetesting::{
-        assert_pass, assert_results_contain, run_check, set_name_entry, test_able,
+    use fontspector_checkapi::{
+        codetesting::{assert_pass, assert_results_contain, run_check, set_name_entry, test_able},
+        StatusCode,
     };
-    use fontspector_checkapi::StatusCode;
 
     #[test]
     fn test_char_restrictions_pass() {

--- a/profile-universal/src/checks/name/no_copyright_on_description.rs
+++ b/profile-universal/src/checks/name/no_copyright_on_description.rs
@@ -37,10 +37,10 @@ mod tests {
 
     use super::no_copyright_on_description;
     use fontations::skrifa::raw::types::NameId;
-    use fontspector_checkapi::codetesting::{
-        assert_pass, assert_results_contain, run_check, set_name_entry, test_able,
+    use fontspector_checkapi::{
+        codetesting::{assert_pass, assert_results_contain, run_check, set_name_entry, test_able},
+        StatusCode,
     };
-    use fontspector_checkapi::StatusCode;
 
     #[test]
     fn test_no_copyright_pass() {

--- a/profile-universal/src/checks/no_vert_and_vrt2.rs
+++ b/profile-universal/src/checks/no_vert_and_vrt2.rs
@@ -56,11 +56,11 @@ mod tests {
     fn test_fail_both_vert_and_vrt2() {
         // Inject a GSUB table containing both 'vert' and 'vrt2' features
         // into Mada-Regular, which should trigger the check failure.
-        use fontations::skrifa::raw::types::Tag;
-        use fontations::skrifa::FontRef;
-        use fontations::write::FontBuilder;
-        use fontspector_checkapi::codetesting::assert_results_contain;
-        use fontspector_checkapi::StatusCode;
+        use fontations::{
+            skrifa::{raw::types::Tag, FontRef},
+            write::FontBuilder,
+        };
+        use fontspector_checkapi::{codetesting::assert_results_contain, StatusCode};
 
         // Minimal valid GSUB table with both vert and vrt2 features
         #[rustfmt::skip]

--- a/profile-universal/src/checks/typographic_family_name.rs
+++ b/profile-universal/src/checks/typographic_family_name.rs
@@ -42,8 +42,10 @@ mod tests {
     use std::collections::HashMap;
 
     use super::typographic_family_name;
-    use fontspector_checkapi::codetesting::{assert_pass, run_check_with_config, test_able};
-    use fontspector_checkapi::{TestableCollection, TestableType};
+    use fontspector_checkapi::{
+        codetesting::{assert_pass, run_check_with_config, test_able},
+        TestableCollection, TestableType,
+    };
 
     #[test]
     fn test_typographic_family_name_pass() {

--- a/profile-universal/src/checks/valid_glyphnames.rs
+++ b/profile-universal/src/checks/valid_glyphnames.rs
@@ -1,7 +1,9 @@
 use std::collections::HashSet;
 
-use fontations::skrifa::raw::{types::Version16Dot16, TableProvider};
-use fontations::skrifa::{GlyphId as SkrifaGlyphId, MetadataProvider};
+use fontations::skrifa::{
+    raw::{types::Version16Dot16, TableProvider},
+    GlyphId as SkrifaGlyphId, MetadataProvider,
+};
 use fontspector_checkapi::{prelude::*, skip, testfont, FileTypeConvert, Metadata};
 use itertools::Itertools;
 use serde_json::json;

--- a/profile-universal/src/checks/varfont_duplexed_axis_reflow.rs
+++ b/profile-universal/src/checks/varfont_duplexed_axis_reflow.rs
@@ -309,8 +309,10 @@ fn grovel_item_variation_store(
 #[cfg(test)]
 mod tests {
     use super::varfont_duplexed_axis_reflow;
-    use fontspector_checkapi::codetesting::{assert_results_contain, run_check, test_able};
-    use fontspector_checkapi::StatusCode;
+    use fontspector_checkapi::{
+        codetesting::{assert_results_contain, run_check, test_able},
+        StatusCode,
+    };
 
     #[test]
     fn test_duplexed_axis_reflow_grad() {


### PR DESCRIPTION
- **fix(googlefonts): Check full names match against METADATA for varfonts**
- **chore: cargo fmt**
