### PR TITLE
feat(googlefonts): metadata/license also checks license matches license file

### DIFF
--- a/profile-googlefonts/src/checks/googlefonts/metadata/license.rs
+++ b/profile-googlefonts/src/checks/googlefonts/metadata/license.rs
@@ -7,35 +7,80 @@ use fontspector_checkapi::prelude::*;
         The license field in METADATA.pb must contain one of the
         three values \"APACHE2\", \"UFL\" or \"OFL\". (New fonts should
         generally be OFL unless there are special circumstances.)
+
+        Additionally, the value must agree with the actual license file
+        shipped with the family: an OFL.txt file means the license must
+        be \"OFL\", a UFL.txt file means \"UFL\", and a LICENSE.txt file
+        means \"APACHE2\". A mismatch between the METADATA.pb license
+        field and the license file would publish the family under a
+        license different from the one the font actually carries.
     ",
-    applies_to = "MDPB",
     proposal="https://github.com/fonttools/fontbakery/issues/4829",  // legacy check
-    title="METADATA.pb license is \"APACHE2\", \"UFL\" or \"OFL\"?"
+    proposal="https://github.com/fonttools/fontspector/issues/778",
+    title="METADATA.pb license is \"APACHE2\", \"UFL\" or \"OFL\" and matches the family's license file?",
+    implementation="all"
 )]
-fn license(c: &Testable, _context: &Context) -> CheckFnResult {
-    let msg = family_proto(c)?;
-    if msg.license() != "APACHE2" && msg.license() != "UFL" && msg.license() != "OFL" {
-        Ok(Status::just_one_fail(
+fn license(c: &TestableCollection, _context: &Context) -> CheckFnResult {
+    let mdpb = c
+        .get_file("METADATA.pb")
+        .ok_or_else(|| FontspectorError::skip("no-mdpb", "No METADATA.pb file found"))?;
+    let msg = family_proto(mdpb)?;
+    let declared = msg.license();
+    let mut problems = vec![];
+
+    if declared != "APACHE2" && declared != "UFL" && declared != "OFL" {
+        problems.push(Status::fail(
             "bad-license",
             &format!(
-                "'METADATA.pb license field (\"{}\") must be \"APACHE2\", \"UFL\" or \"OFL\".",
-                msg.license()
+                "METADATA.pb license field (\"{declared}\") must be \"APACHE2\", \"UFL\" or \"OFL\"."
             ),
-        ))
-    } else {
-        Ok(Status::just_one_pass())
+        ));
     }
+
+    let expected_from_file = if c.get_file("OFL.txt").is_some() {
+        Some(("OFL.txt", "OFL"))
+    } else if c.get_file("UFL.txt").is_some() {
+        Some(("UFL.txt", "UFL"))
+    } else if c.get_file("LICENSE.txt").is_some() {
+        Some(("LICENSE.txt", "APACHE2"))
+    } else {
+        None
+    };
+
+    if let Some((filename, expected)) = expected_from_file {
+        if declared != expected {
+            problems.push(Status::fail(
+                "mismatch",
+                &format!(
+                    "METADATA.pb license field is \"{declared}\" but the family ships a {filename} file, which means the license should be \"{expected}\"."
+                ),
+            ));
+        }
+    }
+
+    return_result(problems)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::license;
     use fontspector_checkapi::{
-        codetesting::{assert_pass, assert_results_contain, run_check, test_able},
-        StatusCode, Testable,
+        codetesting::{assert_pass, assert_results_contain, run_check_with_config, test_able},
+        StatusCode, Testable, TestableCollection, TestableType,
     };
 
-    fn with_license(value: &str) -> Testable {
+    fn run(files: Vec<Testable>) -> Option<fontspector_checkapi::CheckResult> {
+        let collection = TestableCollection::from_testables(files, None);
+        run_check_with_config(
+            license,
+            TestableType::Collection(&collection),
+            HashMap::new(),
+        )
+    }
+
+    fn metadata_with_license(value: &str) -> Testable {
         let mdpb = test_able("familysans/METADATA.pb");
         let metadata = String::from_utf8(mdpb.contents.clone())
             .unwrap_or_else(|e| panic!("Invalid UTF-8 in METADATA.pb test fixture: {e}"));
@@ -45,13 +90,52 @@ mod tests {
 
     #[test]
     fn test_metadata_license_values() {
-        assert_pass(&run_check(license, with_license("APACHE2")));
-        assert_pass(&run_check(license, with_license("UFL")));
-        assert_pass(&run_check(license, with_license("OFL")));
+        // Standalone METADATA.pb with no license file: only the value is validated.
+        assert_pass(&run(vec![metadata_with_license("APACHE2")]));
+        assert_pass(&run(vec![metadata_with_license("UFL")]));
+        assert_pass(&run(vec![metadata_with_license("OFL")]));
 
         for bad in ["APACHE", "Apache", "Ufl", "Ofl", "Open Font License"] {
-            let results = run_check(license, with_license(bad));
-            assert_results_contain(&results, StatusCode::Fail, Some("bad-license".to_string()));
+            assert_results_contain(
+                &run(vec![metadata_with_license(bad)]),
+                StatusCode::Fail,
+                Some("bad-license".to_string()),
+            );
         }
+    }
+
+    #[test]
+    fn test_metadata_license_matches_license_file() {
+        // METADATA.pb says OFL and an OFL.txt is shipped: pass.
+        assert_pass(&run(vec![
+            test_able("cabinvf/METADATA.pb"),
+            test_able("cabinvf/OFL.txt"),
+        ]));
+
+        // METADATA.pb says APACHE2 but an OFL.txt is shipped: mismatch.
+        assert_results_contain(
+            &run(vec![
+                metadata_with_license("APACHE2"),
+                test_able("mada/OFL.txt"),
+            ]),
+            StatusCode::Fail,
+            Some("mismatch".to_string()),
+        );
+
+        // METADATA.pb says OFL but a LICENSE.txt (Apache) is shipped: mismatch.
+        assert_results_contain(
+            &run(vec![
+                metadata_with_license("OFL"),
+                test_able("source-sans-pro/LICENSE.txt"),
+            ]),
+            StatusCode::Fail,
+            Some("mismatch".to_string()),
+        );
+
+        // METADATA.pb says APACHE2 and a LICENSE.txt is shipped: pass.
+        assert_pass(&run(vec![
+            metadata_with_license("APACHE2"),
+            test_able("source-sans-pro/LICENSE.txt"),
+        ]));
     }
 }


### PR DESCRIPTION
Extend googlefonts/metadata/license to verify the METADATA.pb license field agrees with the license file shipped with the family (OFL.txt -> OFL, UFL.txt -> UFL, LICENSE.txt -> APACHE2). Motivated by google/fonts#10195, where Roboto Mono shipped as Apache2 in METADATA.pb while actually being OFL.

The check now operates on a TestableCollection so it can see sibling files; the existing bad-license validation is preserved and a new mismatch failure id is added.

Assisted by Claude Opus 4.7 (1M context)

(Fixes #778)