### PR TITLE
fix(name/italic_names): wrong message, must be name ID 17 and not 16.

### DIFF
--- a/profile-universal/src/checks/name/italic_names.rs
+++ b/profile-universal/src/checks/name/italic_names.rs
@@ -75,7 +75,7 @@ fn italic_names(t: &Testable, _context: &Context) -> CheckFnResult {
         .next()
     {
         if !typo_subfamily_name.ends_with("Italic") {
-            let message = "Name ID 16 (Typographic Family Name) must contain 'Italic'.";
+            let message = "Name ID 17 (Typographic Subfamily Name) must contain 'Italic'.";
             let mut status = Status::fail("bad-typographicsubfamilyname", message);
             status.add_metadata(Metadata::TableProblem {
                 table_tag: "name".to_string(),


### PR DESCRIPTION
## Description
I crossed by a typo in the output of the check name/italic_names and fixed it. I have not created an issue for that, because it was faster to fix it, simply. I hope this is ok for you.

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

