### PR TITLE
fix(cli): make --verbose imply --full-lists

### DIFF
--- a/fontspector-cli/src/args.rs
+++ b/fontspector-cli/src/args.rs
@@ -38,7 +38,7 @@ pub struct Args {
     #[clap(short = 'x', long)]
     pub exclude_checkid: Option<Vec<String>>,
 
-    /// Report full lists of items instead of abbreviated lists
+    /// Report full lists of items instead of abbreviated lists (also implied by --verbose)
     #[clap(long)]
     pub full_lists: bool,
 

--- a/fontspector-cli/src/main.rs
+++ b/fontspector-cli/src/main.rs
@@ -169,7 +169,7 @@ fn main() {
             network_timeout: Some(10), // XXX
             configuration: HashMap::new(),
             check_metadata: serde_json::Value::Null,
-            full_lists: args.full_lists,
+            full_lists: args.full_lists || args.verbose > 0,
             cache: Default::default(),
             overrides,
             check_id: None,


### PR DESCRIPTION
Passing `-v` raised the log level but check results still abbreviate lists to 9 items plus "... and N others" (e.g. `opentype/varfont/STAT_axis_record_for_each_axis` on a many-axis font).

Now any `-v` also enables full lists, so verbose output reports every item. The `--full-lists` help text mentions the new behavior.
