### PR TITLE
feat(monotype): add "monotype/widthclass"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,6 +1833,7 @@ dependencies = [
  "regex",
  "serde_json",
  "skrifa 0.46.2",
+ "write-fonts 0.52.0",
 ]
 
 [[package]]

--- a/profile-monotype/Cargo.toml
+++ b/profile-monotype/Cargo.toml
@@ -16,6 +16,7 @@ fontspector-checkapi = { path = "../fontspector-checkapi", features = [
     "kurbo",
 ], version = "1.0.0" }
 skrifa = { workspace = true }
+write-fonts = { workspace = true }
 itertools = { workspace = true }
 serde_json = { workspace = true }
 regex = { workspace = true }

--- a/profile-monotype/src/checks/monotype/mod.rs
+++ b/profile-monotype/src/checks/monotype/mod.rs
@@ -2,3 +2,5 @@
 // TODO: add Monotype-specific checks
 mod fstype;
 pub use fstype::fstype;
+mod widthclass;
+pub use widthclass::widthclass;

--- a/profile-monotype/src/checks/monotype/widthclass.rs
+++ b/profile-monotype/src/checks/monotype/widthclass.rs
@@ -124,7 +124,7 @@ mod tests {
             (3, "Cond Italic", None),
             (3, "Cond Regular Italic", None),
             (4, "Cond Regular Italic", Some("For OS/2 usWidthClass 4 we expect [\"SemiCond\", \"Semi-Cond\", \"Semi-Condensed\"], but got 'Cond Regular Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
-            (10, "XXWide", None),
+            (10, "XXWide", Some("OS/2 usWidthClass 10 does not match specifications. We expect: XXCond 1, XCond 2, Cond 3, SemiCond 4, (Normal) 5, SemiWide 6, Wide 7, XWide 8, XXWide 9.".to_string())),
             ];
         for (width_class_value, style_name, expected_result) in width_tests {
             let mut font_builder = FontBuilder::new();

--- a/profile-monotype/src/checks/monotype/widthclass.rs
+++ b/profile-monotype/src/checks/monotype/widthclass.rs
@@ -1,0 +1,172 @@
+use fontspector_checkapi::{prelude::*, testfont, FileTypeConvert};
+use skrifa::raw::TableProvider;
+
+fn get_expected_width_name(width_class: u16) -> Option<&'static [&'static str]> {
+    match width_class {
+        1 => Some(&["XXCond", "Ultra-Condensed", "Ultra-Cond"]),
+        2 => Some(&["XCond", "Extra-Condensed", "Extra-Cond"]),
+        3 => Some(&["Cond", "Condensed"]),
+        4 => Some(&["SemiCond", "Semi-Cond", "Semi-Condensed"]),
+        5 => Some(&["Normal"]),
+        6 => Some(&["SemiWide", "Semi-Wide", "Semi-Expanded"]),
+        7 => Some(&["Wide", "Expanded"]),
+        8 => Some(&["XWide", "Extra-Wide", "Extra-Expanded"]),
+        9 => Some(&["XXWide", "Ultra-Wide", "Ultra-Expanded"]),
+        _ => None,
+    }
+}
+
+#[check(
+    id = "monotype/widthclass",
+    rationale = "
+        We expect the following OS/2 usWidthClass values:
+
+        XXCond 1
+        XCond 2
+        Cond 3
+        SemiCond 4
+        Normal 5
+        SemiWide 6
+        Wide 7
+        XWide 8
+        XXWide 9
+    ",
+    proposal = "https://github.com/Monotype/fontspector/issues/1",
+    title = "Check the OS/2 usWidthClass is appropriate for the font's best SubFamily name."
+)]
+fn widthclass(t: &Testable, _context: &Context) -> CheckFnResult {
+    let f = testfont!(t);
+    let value = f.font().os2()?.us_width_class();
+    let style_name = f.best_subfamilyname().unwrap_or("Regular".to_string());
+    let style_name_parts = style_name.split(' ').collect::<Vec<_>>();
+    let expected_width_names = get_expected_width_name(value);
+
+    if value == 5 && is_normal_width(&style_name) {
+        return Ok(Status::just_one_pass());
+    }
+
+    if let Some(expected_names) = expected_width_names {
+        for width_name in expected_names {
+            if style_name_parts.contains(width_name) {
+                return Ok(Status::just_one_pass());
+            }
+        }
+        Ok(Status::just_one_fail(
+            "bad-width-class-value", 
+            &format!(
+                "For OS/2 usWidthClass {value} we expect {expected_names:?}, but got '{style_name}'. Either usWidthClass is wrong or style name. Please investigate."
+            )
+        ))
+    } else {
+        Ok(Status::just_one_fail(
+            "bad-width-class-value",
+            &format!(
+                "OS/2 usWidthClass {value} does not match specifications. We expect: XXCond 1, XCond 2, Cond 3, SemiCond 4, (Normal) 5, SemiWide 6, Wide 7, XWide 8, XXWide 9."
+            )
+        ))
+    }
+}
+
+fn is_normal_width(style_name: &str) -> bool {
+    let style_name_lower = style_name.to_lowercase();
+
+    // if any width is in the style name, it's not regular
+    let non_regular_indicators = [
+        "cond", // includes XXCond, XCond, Cond, SemiCond
+        "wide", // includes xwide, xxwide, extra-wide, ultra-wide
+        "expand", // includes extra-expanded, ultra-expanded
+    ];
+
+    for indicator in non_regular_indicators.iter() {
+        if style_name_lower.contains(indicator) {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+    use fontspector_checkapi::{Context, Testable};
+    use write_fonts::{
+        tables::{
+            maxp::Maxp,
+            name::{Name, NameRecord},
+            os2::Os2,
+        },
+        types::NameId,
+        FontBuilder,
+    };
+
+    #[test]
+    fn test_widthclass() {
+        let width_tests = [
+            (5, "Hairline", None),
+            (5, "Cond Regular", Some("For OS/2 usWidthClass 5 we expect [\"Normal\"], but got 'Cond Regular'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
+            (3, "Condensed Black", None),
+            (2, "XCond SemiBold Italic", None),
+            (5, "XCond SemiBold Italic", Some("For OS/2 usWidthClass 5 we expect [\"Normal\"], but got 'XCond SemiBold Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
+            (6, "Semi-Wide SemiBold Italic", None),
+            (7, "Semi-Wide SemiBold Italic", Some("For OS/2 usWidthClass 7 we expect [\"Wide\", \"Expanded\"], but got 'Semi-Wide SemiBold Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
+            (9, "XXWide Hair Italic", None),
+            (5, "Whatever Thin", None),
+            (5, "ExtraLight", None),
+            (5, "XLight", None),
+            (5, "Light", None),
+            (5, "XBlack", None),
+            (5, "XBlack", None),
+            (5, "Italic", None),
+            (5, "SemiLight", None),
+            (5, "SemiLight Italic", None),
+            (3, "Cond Italic", None),
+            (3, "Cond Regular Italic", None),
+            (4, "Cond Regular Italic", Some("For OS/2 usWidthClass 4 we expect [\"SemiCond\", \"Semi-Cond\", \"Semi-Condensed\"], but got 'Cond Regular Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
+            (10, "XXWide", None),
+            ];
+        for (width_class_value, style_name, expected_result) in width_tests {
+            let mut font_builder = FontBuilder::new();
+            let maxp = Maxp::default();
+            font_builder.add_table(&maxp).unwrap();
+
+            let os2: Os2 = Os2 {
+                us_width_class: width_class_value,
+                ..Default::default()
+            };
+            font_builder.add_table(&os2).unwrap();
+
+            let mut name: Name = Name::default();
+            let mut new_records = Vec::new();
+            // english default 3/1/1033
+            let name_rec_fam = NameRecord::new(
+                3,
+                1,
+                1033,
+                NameId::new(16),
+                "A Family Name".to_string().into(),
+            );
+            new_records.push(name_rec_fam);
+            let name_rec_sub =
+                NameRecord::new(3, 1, 1033, NameId::new(17), style_name.to_string().into());
+            new_records.push(name_rec_sub);
+            new_records.sort();
+            name.name_record = new_records;
+            font_builder.add_table(&name).unwrap();
+
+            let font = font_builder.build();
+
+            let testable = Testable::new_with_contents("demo.otf", font);
+            let context = Context {
+                ..Default::default()
+            };
+            let result = widthclass_impl(&testable, &context)
+                .unwrap()
+                .next()
+                .unwrap();
+
+            assert_eq!(result.message, expected_result);
+        }
+    }
+}

--- a/profile-monotype/src/checks/monotype/widthclass.rs
+++ b/profile-monotype/src/checks/monotype/widthclass.rs
@@ -37,11 +37,27 @@ fn get_expected_width_name(width_class: u16) -> Option<&'static [&'static str]> 
 fn widthclass(t: &Testable, _context: &Context) -> CheckFnResult {
     let f = testfont!(t);
     let value = f.font().os2()?.us_width_class();
-    let style_name = f.best_subfamilyname().unwrap_or("Regular".to_string());
-    let style_name_parts = style_name.split(' ').collect::<Vec<_>>();
+    let best_family_name = if let Some(fam_name) = f.best_familyname() {
+        fam_name
+    } else {
+        return Ok(Status::just_one_fail(
+            "missing-family-name",
+            "The font is missing a best family name.",
+        ));
+    };
+    let best_subfamily_name = if let Some(sub_name) = f.best_subfamilyname() {
+        sub_name
+    } else {
+        return Ok(Status::just_one_fail(
+            "missing-subfamily-name",
+            "The font is missing a best subfamily name.",
+        ));
+    };
+    let best_full_name = format!("{} {}", best_family_name, best_subfamily_name);
+    let style_name_parts = best_full_name.split(' ').collect::<Vec<_>>();
     let expected_width_names = get_expected_width_name(value);
 
-    if value == 5 && is_normal_width(&style_name) {
+    if value == 5 && is_normal_width(&best_full_name) {
         return Ok(Status::just_one_pass());
     }
 
@@ -54,15 +70,13 @@ fn widthclass(t: &Testable, _context: &Context) -> CheckFnResult {
         Ok(Status::just_one_fail(
             "width-class-name-value-mismatch", 
             &format!(
-                "For OS/2 usWidthClass {value} we expect {expected_names:?}, but got '{style_name}'. Either usWidthClass is wrong or style name. Please investigate."
+                "For OS/2 usWidthClass {value} we expect {expected_names:?}, but got '{best_full_name}'. Either usWidthClass is wrong or style name. Please investigate."
             )
         ))
     } else {
         Ok(Status::just_one_fail(
             "bad-width-class-value",
-            &format!(
-                "OS/2 usWidthClass {value} does not match specifications. We expect: XXCond 1, XCond 2, Cond 3, SemiCond 4, (Normal) 5, SemiWide 6, Wide 7, XWide 8, XXWide 9."
-            )
+            &format!("OS/2 usWidthClass {value} does not match specifications (1-9)."),
         ))
     }
 }
@@ -105,12 +119,12 @@ mod tests {
     fn test_widthclass() {
         let width_tests = [
             (5, "A Family Name", "Hairline", None),
-            (5, "A Family Name", "Cond Regular", Some("For OS/2 usWidthClass 5 we expect [\"Normal\"], but got 'Cond Regular'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
+            (5, "A Family Name", "Cond Regular", Some("For OS/2 usWidthClass 5 we expect [\"Normal\"], but got 'A Family Name Cond Regular'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
             (3, "A Family Name", "Condensed Black", None),
             (2, "A Family Name", "XCond SemiBold Italic", None),
-            (5, "A Family Name", "XCond SemiBold Italic", Some("For OS/2 usWidthClass 5 we expect [\"Normal\"], but got 'XCond SemiBold Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
+            (5, "A Family Name", "XCond SemiBold Italic", Some("For OS/2 usWidthClass 5 we expect [\"Normal\"], but got 'A Family Name XCond SemiBold Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
             (6, "A Family Name", "Semi-Wide SemiBold Italic", None),
-            (7, "A Family Name", "Semi-Wide SemiBold Italic", Some("For OS/2 usWidthClass 7 we expect [\"Wide\", \"Expanded\"], but got 'Semi-Wide SemiBold Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
+            (7, "A Family Name", "Semi-Wide SemiBold Italic", Some("For OS/2 usWidthClass 7 we expect [\"Wide\", \"Expanded\"], but got 'A Family Name Semi-Wide SemiBold Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
             (9, "A Family Name", "XXWide Hair Italic", None),
             (5, "A Family Name", "Whatever Thin", None),
             (5, "A Family Name", "ExtraLight", None),
@@ -122,8 +136,8 @@ mod tests {
             (5, "A Family Name", "SemiLight Italic", None),
             (3, "A Family Name", "Cond Italic", None),
             (3, "A Family Name", "Cond Regular Italic", None),
-            (4, "A Family Name", "Cond Regular Italic", Some("For OS/2 usWidthClass 4 we expect [\"SemiCond\", \"Semi-Cond\", \"Semi-Condensed\"], but got 'Cond Regular Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
-            (10, "A Family Name", "XXWide", Some("OS/2 usWidthClass 10 does not match specifications. We expect: XXCond 1, XCond 2, Cond 3, SemiCond 4, (Normal) 5, SemiWide 6, Wide 7, XWide 8, XXWide 9.".to_string())),
+            (4, "A Family Name", "Cond Regular Italic", Some("For OS/2 usWidthClass 4 we expect [\"SemiCond\", \"Semi-Cond\", \"Semi-Condensed\"], but got 'A Family Name Cond Regular Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
+            (10, "A Family Name", "XXWide", Some("OS/2 usWidthClass 10 does not match specifications (1-9).".to_string())),
             (3, "A Family Name Cond", "Bold", None),
             (7, "A Family Name Wide", "Bold", None),
             ];

--- a/profile-monotype/src/checks/monotype/widthclass.rs
+++ b/profile-monotype/src/checks/monotype/widthclass.rs
@@ -72,8 +72,8 @@ fn is_normal_width(style_name: &str) -> bool {
 
     // if any width is in the style name, it's not regular
     let non_regular_indicators = [
-        "cond", // includes XXCond, XCond, Cond, SemiCond
-        "wide", // includes xwide, xxwide, extra-wide, ultra-wide
+        "cond",   // includes XXCond, XCond, Cond, SemiCond
+        "wide",   // includes xwide, xxwide, extra-wide, ultra-wide
         "expand", // includes extra-expanded, ultra-expanded
     ];
 

--- a/profile-monotype/src/checks/monotype/widthclass.rs
+++ b/profile-monotype/src/checks/monotype/widthclass.rs
@@ -140,6 +140,16 @@ mod tests {
             (10, "A Family Name", "XXWide", Some("OS/2 usWidthClass 10 does not match specifications (1-9).".to_string())),
             (3, "A Family Name Cond", "Bold", None),
             (7, "A Family Name Wide", "Bold", None),
+            // Monotype specific width names
+            (1, "A Family Name", "ExtraCompressed Bold", None),
+            (2, "A Family Name", "Compressed Bold", None),
+            (3, "A Family Name", "Condensed Bold", None),
+            (4, "A Family Name", "SemiCondensed Bold", None),
+            (5, "A Family Name", "Bold", None),
+            (6, "A Family Name", "SemiExtended Bold", None),
+            (7, "A Family Name", "Extended Bold", None),
+            (8, "A Family Name", "Wide Bold", None),
+            (9, "A Family Name", "ExtraWide Bold", None),
             ];
         for (width_class_value, family_name, style_name, expected_result) in width_tests {
             let mut font_builder = FontBuilder::new();

--- a/profile-monotype/src/checks/monotype/widthclass.rs
+++ b/profile-monotype/src/checks/monotype/widthclass.rs
@@ -52,7 +52,7 @@ fn widthclass(t: &Testable, _context: &Context) -> CheckFnResult {
             }
         }
         Ok(Status::just_one_fail(
-            "bad-width-class-value", 
+            "width-class-name-value-mismatch", 
             &format!(
                 "For OS/2 usWidthClass {value} we expect {expected_names:?}, but got '{style_name}'. Either usWidthClass is wrong or style name. Please investigate."
             )

--- a/profile-monotype/src/checks/monotype/widthclass.rs
+++ b/profile-monotype/src/checks/monotype/widthclass.rs
@@ -3,15 +3,15 @@ use skrifa::raw::TableProvider;
 
 fn get_expected_width_name(width_class: u16) -> Option<&'static [&'static str]> {
     match width_class {
-        1 => Some(&["ExtraCompressed", "XXCond", "Ultra-Condensed", "Ultra-Cond"]),
-        2 => Some(&["Compressed", "XCond", "Extra-Condensed", "Extra-Cond"]),
-        3 => Some(&["Condensed", "Cond"]),
-        4 => Some(&["SemiCondensed", "SemiCond", "Semi-Cond", "Semi-Condensed"]),
+        1 => Some(&["ExtraCompressed", "XXCond", "Ultra-Condensed", "Ultra-Cond", "XCm", "XComp", "ExtraComp"]),
+        2 => Some(&["Compressed", "XCond", "Extra-Condensed", "Extra-Cond", "Cm", "Comp"]),
+        3 => Some(&["Condensed", "Cond", "Cn"]),
+        4 => Some(&["SemiCondensed", "SemiCond", "Semi-Cond", "Semi-Condensed", "SmCond", "SmCn"]),
         5 => Some(&["Normal"]),
-        6 => Some(&["SemiExtended", "SemiWide", "Semi-Wide", "Semi-Expanded"]),
-        7 => Some(&["Extended", "Wide", "Expanded"]),
-        8 => Some(&["Wide", "XWide", "Extra-Wide", "Extra-Expanded"]),
-        9 => Some(&["ExtraWide", "XXWide", "Ultra-Wide", "Ultra-Expanded"]),
+        6 => Some(&["SemiExtended", "SemiWide", "Semi-Wide", "Semi-Expanded", "SemiExt", "SmExt"]),
+        7 => Some(&["Extended", "Wide", "Expanded", "Ext"]),
+        8 => Some(&["Wide", "XWide", "Extra-Wide", "Extra-Expanded", "Wd"]),
+        9 => Some(&["ExtraWide", "XXWide", "Ultra-Wide", "Ultra-Expanded", "XtraWd", "XWd"]),
         _ => None,
     }
 }
@@ -81,8 +81,8 @@ fn widthclass(t: &Testable, _context: &Context) -> CheckFnResult {
     }
 }
 
-fn is_normal_width(style_name: &str) -> bool {
-    let style_name_lower = style_name.to_lowercase();
+fn is_normal_width(full_name: &str) -> bool {
+    let full_name_lower = full_name.to_lowercase();
 
     // if any width is in the style name, it's not regular
     let non_regular_indicators = [
@@ -90,10 +90,12 @@ fn is_normal_width(style_name: &str) -> bool {
         "wide",   // includes xwide, xxwide, extra-wide, ultra-wide
         "expand", // includes extra-expanded, ultra-expanded
         "extend", // includes extra-extended, ultra-extended
+        "comp",   // includes Compressed, UltraCompressed, ExtraCompressed, XComp, SemiComp, ...
+        "cm",     // includes XCm, Cm
     ];
 
     for indicator in non_regular_indicators.iter() {
-        if style_name_lower.contains(indicator) {
+        if full_name_lower.contains(indicator) {
             return false;
         }
     }
@@ -125,7 +127,7 @@ mod tests {
             (2, "A Family Name", "XCond SemiBold Italic", None),
             (5, "A Family Name", "XCond SemiBold Italic", Some("For OS/2 usWidthClass 5 we expect [\"Normal\"], but got 'A Family Name XCond SemiBold Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
             (6, "A Family Name", "Semi-Wide SemiBold Italic", None),
-            (7, "A Family Name", "Semi-Wide SemiBold Italic", Some("For OS/2 usWidthClass 7 we expect [\"Extended\", \"Wide\", \"Expanded\"], but got 'A Family Name Semi-Wide SemiBold Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
+            (7, "A Family Name", "Semi-Wide SemiBold Italic", Some("For OS/2 usWidthClass 7 we expect [\"Extended\", \"Wide\", \"Expanded\", \"Ext\"], but got 'A Family Name Semi-Wide SemiBold Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
             (9, "A Family Name", "XXWide Hair Italic", None),
             (5, "A Family Name", "Whatever Thin", None),
             (5, "A Family Name", "ExtraLight", None),
@@ -137,7 +139,7 @@ mod tests {
             (5, "A Family Name", "SemiLight Italic", None),
             (3, "A Family Name", "Cond Italic", None),
             (3, "A Family Name", "Cond Regular Italic", None),
-            (4, "A Family Name", "Cond Regular Italic", Some("For OS/2 usWidthClass 4 we expect [\"SemiCondensed\", \"SemiCond\", \"Semi-Cond\", \"Semi-Condensed\"], but got 'A Family Name Cond Regular Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
+            (4, "A Family Name", "Cond Regular Italic", Some("For OS/2 usWidthClass 4 we expect [\"SemiCondensed\", \"SemiCond\", \"Semi-Cond\", \"Semi-Condensed\", \"SmCond\", \"SmCn\"], but got 'A Family Name Cond Regular Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
             (10, "A Family Name", "XXWide", Some("OS/2 usWidthClass 10 does not match specifications (1-9).".to_string())),
             (3, "A Family Name Cond", "Bold", None),
             (7, "A Family Name Wide", "Bold", None),
@@ -163,6 +165,7 @@ mod tests {
             // add edge cases for width classes 4
             (4, "A Family Name", "SmCond Bold", None),
             (4, "A Family Name", "SmCn Bold", None),
+            (5, "A Family Name", "SmCn Bold", Some("For OS/2 usWidthClass 5 we expect [\"Normal\"], but got 'A Family Name SmCn Bold'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
             // add edge cases for width classes 6
             (6, "A Family Name", "SemiExt Bold", None),
             (6, "A Family Name", "SmExt Bold", None),

--- a/profile-monotype/src/checks/monotype/widthclass.rs
+++ b/profile-monotype/src/checks/monotype/widthclass.rs
@@ -3,15 +3,15 @@ use skrifa::raw::TableProvider;
 
 fn get_expected_width_name(width_class: u16) -> Option<&'static [&'static str]> {
     match width_class {
-        1 => Some(&["XXCond", "Ultra-Condensed", "Ultra-Cond"]),
-        2 => Some(&["XCond", "Extra-Condensed", "Extra-Cond"]),
-        3 => Some(&["Cond", "Condensed"]),
-        4 => Some(&["SemiCond", "Semi-Cond", "Semi-Condensed"]),
+        1 => Some(&["ExtraCompressed", "XXCond", "Ultra-Condensed", "Ultra-Cond"]),
+        2 => Some(&["Compressed", "XCond", "Extra-Condensed", "Extra-Cond"]),
+        3 => Some(&["Condensed", "Cond"]),
+        4 => Some(&["SemiCondensed", "SemiCond", "Semi-Cond", "Semi-Condensed"]),
         5 => Some(&["Normal"]),
-        6 => Some(&["SemiWide", "Semi-Wide", "Semi-Expanded"]),
-        7 => Some(&["Wide", "Expanded"]),
-        8 => Some(&["XWide", "Extra-Wide", "Extra-Expanded"]),
-        9 => Some(&["XXWide", "Ultra-Wide", "Ultra-Expanded"]),
+        6 => Some(&["SemiExtended", "SemiWide", "Semi-Wide", "Semi-Expanded"]),
+        7 => Some(&["Extended", "Wide", "Expanded"]),
+        8 => Some(&["Wide", "XWide", "Extra-Wide", "Extra-Expanded"]),
+        9 => Some(&["ExtraWide", "XXWide", "Ultra-Wide", "Ultra-Expanded"]),
         _ => None,
     }
 }
@@ -21,15 +21,15 @@ fn get_expected_width_name(width_class: u16) -> Option<&'static [&'static str]> 
     rationale = "
         We expect the following OS/2 usWidthClass values:
 
-        XXCond 1
-        XCond 2
-        Cond 3
-        SemiCond 4
-        Normal 5
-        SemiWide 6
-        Wide 7
-        XWide 8
-        XXWide 9
+        ExtraCompressed 1
+        Compressed 2
+        Condensed 3
+        SemiCondensed 4
+        (Normal) 5
+        SemiExtended 6
+        Extended 7
+        Wide 8
+        ExtraWide 9
     ",
     proposal = "https://github.com/Monotype/fontspector/issues/1",
     title = "Check the OS/2 usWidthClass is appropriate for the font's best SubFamily name."
@@ -89,6 +89,7 @@ fn is_normal_width(style_name: &str) -> bool {
         "cond",   // includes XXCond, XCond, Cond, SemiCond
         "wide",   // includes xwide, xxwide, extra-wide, ultra-wide
         "expand", // includes extra-expanded, ultra-expanded
+        "extend", // includes extra-extended, ultra-extended
     ];
 
     for indicator in non_regular_indicators.iter() {
@@ -124,7 +125,7 @@ mod tests {
             (2, "A Family Name", "XCond SemiBold Italic", None),
             (5, "A Family Name", "XCond SemiBold Italic", Some("For OS/2 usWidthClass 5 we expect [\"Normal\"], but got 'A Family Name XCond SemiBold Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
             (6, "A Family Name", "Semi-Wide SemiBold Italic", None),
-            (7, "A Family Name", "Semi-Wide SemiBold Italic", Some("For OS/2 usWidthClass 7 we expect [\"Wide\", \"Expanded\"], but got 'A Family Name Semi-Wide SemiBold Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
+            (7, "A Family Name", "Semi-Wide SemiBold Italic", Some("For OS/2 usWidthClass 7 we expect [\"Extended\", \"Wide\", \"Expanded\"], but got 'A Family Name Semi-Wide SemiBold Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
             (9, "A Family Name", "XXWide Hair Italic", None),
             (5, "A Family Name", "Whatever Thin", None),
             (5, "A Family Name", "ExtraLight", None),
@@ -136,7 +137,7 @@ mod tests {
             (5, "A Family Name", "SemiLight Italic", None),
             (3, "A Family Name", "Cond Italic", None),
             (3, "A Family Name", "Cond Regular Italic", None),
-            (4, "A Family Name", "Cond Regular Italic", Some("For OS/2 usWidthClass 4 we expect [\"SemiCond\", \"Semi-Cond\", \"Semi-Condensed\"], but got 'A Family Name Cond Regular Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
+            (4, "A Family Name", "Cond Regular Italic", Some("For OS/2 usWidthClass 4 we expect [\"SemiCondensed\", \"SemiCond\", \"Semi-Cond\", \"Semi-Condensed\"], but got 'A Family Name Cond Regular Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
             (10, "A Family Name", "XXWide", Some("OS/2 usWidthClass 10 does not match specifications (1-9).".to_string())),
             (3, "A Family Name Cond", "Bold", None),
             (7, "A Family Name Wide", "Bold", None),

--- a/profile-monotype/src/checks/monotype/widthclass.rs
+++ b/profile-monotype/src/checks/monotype/widthclass.rs
@@ -104,28 +104,28 @@ mod tests {
     #[test]
     fn test_widthclass() {
         let width_tests = [
-            (5, "Hairline", None),
-            (5, "Cond Regular", Some("For OS/2 usWidthClass 5 we expect [\"Normal\"], but got 'Cond Regular'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
-            (3, "Condensed Black", None),
-            (2, "XCond SemiBold Italic", None),
-            (5, "XCond SemiBold Italic", Some("For OS/2 usWidthClass 5 we expect [\"Normal\"], but got 'XCond SemiBold Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
-            (6, "Semi-Wide SemiBold Italic", None),
-            (7, "Semi-Wide SemiBold Italic", Some("For OS/2 usWidthClass 7 we expect [\"Wide\", \"Expanded\"], but got 'Semi-Wide SemiBold Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
-            (9, "XXWide Hair Italic", None),
-            (5, "Whatever Thin", None),
-            (5, "ExtraLight", None),
-            (5, "XLight", None),
-            (5, "Light", None),
-            (5, "XBlack", None),
-            (5, "Italic", None),
-            (5, "SemiLight", None),
-            (5, "SemiLight Italic", None),
-            (3, "Cond Italic", None),
-            (3, "Cond Regular Italic", None),
-            (4, "Cond Regular Italic", Some("For OS/2 usWidthClass 4 we expect [\"SemiCond\", \"Semi-Cond\", \"Semi-Condensed\"], but got 'Cond Regular Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
-            (10, "XXWide", Some("OS/2 usWidthClass 10 does not match specifications. We expect: XXCond 1, XCond 2, Cond 3, SemiCond 4, (Normal) 5, SemiWide 6, Wide 7, XWide 8, XXWide 9.".to_string())),
+            (5, "A Family Name", "Hairline", None),
+            (5, "A Family Name", "Cond Regular", Some("For OS/2 usWidthClass 5 we expect [\"Normal\"], but got 'Cond Regular'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
+            (3, "A Family Name", "Condensed Black", None),
+            (2, "A Family Name", "XCond SemiBold Italic", None),
+            (5, "A Family Name", "XCond SemiBold Italic", Some("For OS/2 usWidthClass 5 we expect [\"Normal\"], but got 'XCond SemiBold Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
+            (6, "A Family Name", "Semi-Wide SemiBold Italic", None),
+            (7, "A Family Name", "Semi-Wide SemiBold Italic", Some("For OS/2 usWidthClass 7 we expect [\"Wide\", \"Expanded\"], but got 'Semi-Wide SemiBold Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
+            (9, "A Family Name", "XXWide Hair Italic", None),
+            (5, "A Family Name", "Whatever Thin", None),
+            (5, "A Family Name", "ExtraLight", None),
+            (5, "A Family Name", "XLight", None),
+            (5, "A Family Name", "Light", None),
+            (5, "A Family Name", "XBlack", None),
+            (5, "A Family Name", "Italic", None),
+            (5, "A Family Name", "SemiLight", None),
+            (5, "A Family Name", "SemiLight Italic", None),
+            (3, "A Family Name", "Cond Italic", None),
+            (3, "A Family Name", "Cond Regular Italic", None),
+            (4, "A Family Name", "Cond Regular Italic", Some("For OS/2 usWidthClass 4 we expect [\"SemiCond\", \"Semi-Cond\", \"Semi-Condensed\"], but got 'Cond Regular Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
+            (10, "A Family Name", "XXWide", Some("OS/2 usWidthClass 10 does not match specifications. We expect: XXCond 1, XCond 2, Cond 3, SemiCond 4, (Normal) 5, SemiWide 6, Wide 7, XWide 8, XXWide 9.".to_string())),
             ];
-        for (width_class_value, style_name, expected_result) in width_tests {
+        for (width_class_value, family_name, style_name, expected_result) in width_tests {
             let mut font_builder = FontBuilder::new();
             let maxp = Maxp::default();
             font_builder.add_table(&maxp).unwrap();
@@ -139,13 +139,8 @@ mod tests {
             let mut name: Name = Name::default();
             let mut new_records = Vec::new();
             // english default 3/1/1033
-            let name_rec_fam = NameRecord::new(
-                3,
-                1,
-                1033,
-                NameId::new(16),
-                "A Family Name".to_string().into(),
-            );
+            let name_rec_fam =
+                NameRecord::new(3, 1, 1033, NameId::new(16), family_name.to_string().into());
             new_records.push(name_rec_fam);
             let name_rec_sub =
                 NameRecord::new(3, 1, 1033, NameId::new(17), style_name.to_string().into());

--- a/profile-monotype/src/checks/monotype/widthclass.rs
+++ b/profile-monotype/src/checks/monotype/widthclass.rs
@@ -117,7 +117,6 @@ mod tests {
             (5, "XLight", None),
             (5, "Light", None),
             (5, "XBlack", None),
-            (5, "XBlack", None),
             (5, "Italic", None),
             (5, "SemiLight", None),
             (5, "SemiLight Italic", None),

--- a/profile-monotype/src/checks/monotype/widthclass.rs
+++ b/profile-monotype/src/checks/monotype/widthclass.rs
@@ -151,6 +151,28 @@ mod tests {
             (7, "A Family Name", "Extended Bold", None),
             (8, "A Family Name", "Wide Bold", None),
             (9, "A Family Name", "ExtraWide Bold", None),
+            // add edge cases for width classes 1
+            (1, "A Family Name", "XCm Bold", None),
+            (1, "A Family Name", "XComp Bold", None),
+            (1, "A Family Name", "ExtraComp Bold", None),
+            // add edge cases for width classes 2
+            (2, "A Family Name", "Comp Bold", None),
+            (2, "A Family Name", "Cm Bold", None),
+            // add edge cases for width classes 3
+            (3, "A Family Name", "Cn Bold", None),
+            // add edge cases for width classes 4
+            (4, "A Family Name", "SmCond Bold", None),
+            (4, "A Family Name", "SmCn Bold", None),
+            // add edge cases for width classes 6
+            (6, "A Family Name", "SemiExt Bold", None),
+            (6, "A Family Name", "SmExt Bold", None),
+            // add edge cases for width classes 7
+            (7, "A Family Name", "Ext Bold", None),
+            // add edge cases for width classes 8
+            (8, "A Family Name", "Wd Bold", None),
+            // add edge cases for width classes 9
+            (9, "A Family Name", "XtraWd Bold", None),
+            (9, "A Family Name", "XWd Bold", None),
             ];
         for (width_class_value, family_name, style_name, expected_result) in width_tests {
             let mut font_builder = FontBuilder::new();

--- a/profile-monotype/src/checks/monotype/widthclass.rs
+++ b/profile-monotype/src/checks/monotype/widthclass.rs
@@ -124,6 +124,8 @@ mod tests {
             (3, "A Family Name", "Cond Regular Italic", None),
             (4, "A Family Name", "Cond Regular Italic", Some("For OS/2 usWidthClass 4 we expect [\"SemiCond\", \"Semi-Cond\", \"Semi-Condensed\"], but got 'Cond Regular Italic'. Either usWidthClass is wrong or style name. Please investigate.".to_string())),
             (10, "A Family Name", "XXWide", Some("OS/2 usWidthClass 10 does not match specifications. We expect: XXCond 1, XCond 2, Cond 3, SemiCond 4, (Normal) 5, SemiWide 6, Wide 7, XWide 8, XXWide 9.".to_string())),
+            (3, "A Family Name Cond", "Bold", None),
+            (7, "A Family Name Wide", "Bold", None),
             ];
         for (width_class_value, family_name, style_name, expected_result) in width_tests {
             let mut font_builder = FontBuilder::new();

--- a/profile-monotype/src/lib.rs
+++ b/profile-monotype/src/lib.rs
@@ -40,6 +40,7 @@ impl fontspector_checkapi::ProfileProvider for Monotype {
                 ]),
             )
             // TODO: implement more Monotype-specific checks
+            .add_and_register_check(checks::monotype::widthclass)
             .include_profile("universal")
             .with_configuration_defaults(
                 "universal/required_name_ids",


### PR DESCRIPTION
## Description
Relates to issue [#1](https://github.com/Monotype/fontspector/issues/1)

This is a test for checking if the width class value of a font matches with the subfamily name.
This is a first draft to get feedback.

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

