### PR TITLE
feat(opentype/fsselection): improvements for fonts with unusual file names

### DIFF
--- a/fontspector-checkapi/src/font.rs
+++ b/fontspector-checkapi/src/font.rs
@@ -121,7 +121,18 @@ impl TestFont<'_> {
                 }
             }
         }
-        None
+        if self.is_bold().ok()? {
+            if self.is_italic().ok()? {
+                return Some("BoldItalic");
+            } else {
+                return Some("Bold");
+            }
+        } else {
+            if self.is_italic().ok()? {
+                return Some("Italic");
+            }
+            return Some("Regular");
+        }
     }
 
     /// Is this a RIBBI font?
@@ -152,6 +163,29 @@ impl TestFont<'_> {
         }
         let post = font.post()?;
         if post.italic_angle().to_f32() != 0.0 {
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    /// Is this font bold?
+    pub fn is_bold(&self) -> Result<bool, ReadError> {
+        let font = self.font();
+        let os2 = font.os2()?;
+        if os2.fs_selection().contains(SelectionFlags::BOLD) {
+            return Ok(true);
+        }
+        if os2.us_weight_class() == 700 {
+            return Ok(true);
+        }
+        let head = font.head()?;
+        if head.mac_style().contains(MacStyle::BOLD) {
+            return Ok(true);
+        }
+        if self
+            .get_name_entry_strings(StringId::FULL_NAME)
+            .any(|x| x.to_lowercase().contains("bold"))
+        {
             return Ok(true);
         }
         Ok(false)

--- a/fontspector-checkapi/src/font.rs
+++ b/fontspector-checkapi/src/font.rs
@@ -123,15 +123,16 @@ impl TestFont<'_> {
         }
         if self.is_bold().ok()? {
             if self.is_italic().ok()? {
-                return Some("BoldItalic");
+                Some("BoldItalic")
             } else {
-                return Some("Bold");
+                Some("Bold")
             }
         } else {
             if self.is_italic().ok()? {
-                return Some("Italic");
+                Some("Italic")
+            } else {
+                Some("Regular")
             }
-            return Some("Regular");
         }
     }
 

--- a/profile-opentype/src/checks/opentype/fsselection.rs
+++ b/profile-opentype/src/checks/opentype/fsselection.rs
@@ -228,16 +228,7 @@ mod tests {
     #[test]
     fn test_fsselection_macstyle_italic_mismatch__file_name_Ita_pass() {
         // filename with Ita (Italic) (Legacy fonts may use it)
-        // Set ITALIC in fsSelection but not in macStyle
-        let mut testable = test_able("cabin/Cabin-Italic.ttf");
-        let new_bytes = {
-            let f = TTF.from_testable(&testable).unwrap();
-            let mut os2: write_fonts::tables::os2::Os2 = f.font().os2().unwrap().to_owned_table();
-            os2.fs_selection |= SelectionFlags::ITALIC;
-            os2.fs_selection.remove(SelectionFlags::REGULAR);
-            f.rebuild_with_new_table(&os2).unwrap()
-        };
-        testable.set(new_bytes);
+        let testable = test_able("cabin/Cabin-Italic.ttf");
         let new_testable =
             Testable::new_with_contents("Test-Ita.ttf".to_string(), testable.contents);
         let result = run_check(fsselection, new_testable);

--- a/profile-opentype/src/checks/opentype/fsselection.rs
+++ b/profile-opentype/src/checks/opentype/fsselection.rs
@@ -243,4 +243,27 @@ mod tests {
         let result = run_check(fsselection, new_testable);
         assert_pass(&result);
     }
+
+    #[test]
+    fn test_fsselection_macstyle_italic_mismatch__file_name_Ita_fail() {
+        // filename with Ita (Italic) (Legacy fonts may use it)
+        // Set ITALIC in fsSelection but not in macStyle
+        let mut testable = test_able("cabin/Cabin-Regular.ttf");
+        let new_bytes = {
+            let f = TTF.from_testable(&testable).unwrap();
+            let mut os2: write_fonts::tables::os2::Os2 = f.font().os2().unwrap().to_owned_table();
+            os2.fs_selection |= SelectionFlags::ITALIC;
+            os2.fs_selection.remove(SelectionFlags::REGULAR);
+            f.rebuild_with_new_table(&os2).unwrap()
+        };
+        testable.set(new_bytes);
+        let new_testable =
+            Testable::new_with_contents("Test-Ita.ttf".to_string(), testable.contents);
+        let result = run_check(fsselection, new_testable);
+        assert_results_contain(
+            &result,
+            StatusCode::Fail,
+            Some("fsselection-macstyle-italic".to_string()),
+        );
+    }
 }

--- a/profile-opentype/src/checks/opentype/fsselection.rs
+++ b/profile-opentype/src/checks/opentype/fsselection.rs
@@ -226,7 +226,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fsselection_macstyle_italic_mismatch__file_name_Ita() {
+    fn test_fsselection_macstyle_italic_mismatch__file_name_Ita_pass() {
         // filename with Ita (Italic) (Legacy fonts may use it)
         // Set ITALIC in fsSelection but not in macStyle
         let mut testable = test_able("cabin/Cabin-Italic.ttf");
@@ -241,10 +241,6 @@ mod tests {
         let new_testable =
             Testable::new_with_contents("Test-Ita.ttf".to_string(), testable.contents);
         let result = run_check(fsselection, new_testable);
-        assert_results_contain(
-            &result,
-            StatusCode::Fail,
-            Some("fsselection-macstyle-italic".to_string()),
-        );
+        assert_pass(&result);
     }
 }

--- a/profile-opentype/src/checks/opentype/fsselection.rs
+++ b/profile-opentype/src/checks/opentype/fsselection.rs
@@ -224,4 +224,27 @@ mod tests {
             Some("fsselection-macstyle-italic".to_string()),
         );
     }
+
+    #[test]
+    fn test_fsselection_macstyle_italic_mismatch__file_name_Ita() {
+        // filename with Ita (Italic) (Legacy fonts may use it)
+        // Set ITALIC in fsSelection but not in macStyle
+        let mut testable = test_able("cabin/Cabin-Italic.ttf");
+        let new_bytes = {
+            let f = TTF.from_testable(&testable).unwrap();
+            let mut os2: write_fonts::tables::os2::Os2 = f.font().os2().unwrap().to_owned_table();
+            os2.fs_selection |= SelectionFlags::ITALIC;
+            os2.fs_selection.remove(SelectionFlags::REGULAR);
+            f.rebuild_with_new_table(&os2).unwrap()
+        };
+        testable.set(new_bytes);
+        let new_testable =
+            Testable::new_with_contents("Test-Ita.ttf".to_string(), testable.contents);
+        let result = run_check(fsselection, new_testable);
+        assert_results_contain(
+            &result,
+            StatusCode::Fail,
+            Some("fsselection-macstyle-italic".to_string()),
+        );
+    }
 }


### PR DESCRIPTION
## Description
Relates to issue [#2](https://github.com/Monotype/fontspector/issues/2)

Monotype requested a test which to check "_Does OS/2.fsSelection.italic value match head.macStyle.italic?_", but this is already covered by `opentype/fsselection`, BUT the test relies on 'Italic' be part of the file name. Monotype has to deal with a lot of legacy fonts which may have different fiel name conventions. Having said that, it might be possible that the name includes only '_Ita_' for '_Italic_'. That's why I have updated `font.style` by using `is_italic` and `is_bold` (which is newly created).

This is a draft PR to get feedback as early as possible.

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

