### PR TITLE
fix: Promote Adobe's STAT_strings to universal, move current to GF

### DIFF
--- a/profile-adobe/src/checks/adobefonts/mod.rs
+++ b/profile-adobe/src/checks/adobefonts/mod.rs
@@ -1,6 +1,3 @@
-#[allow(non_snake_case)]
-mod STAT_strings;
-pub use STAT_strings::STAT_strings;
 mod unsupported_tables;
 pub use unsupported_tables::unsupported_tables;
 mod nameid_1_win_english;

--- a/profile-adobe/src/lib.rs
+++ b/profile-adobe/src/lib.rs
@@ -9,12 +9,12 @@ impl fontspector_checkapi::ProfileProvider for Adobe {
     fn register(&self, cr: &mut Registry) -> Result<(), FontspectorError> {
         let builder = ProfileBuilder::new()
             .include_profile("universal")
+            // The universal profile now includes the "Adobe version" STAT_strings check, so we no longer need to add it here.
             .add_section("Adobe Fonts Checks")
             // "Adobe Fonts Checks" = ["adobefonts/family/consistent_upm", "adobefonts/nameid_1_win_english", "adobefonts/unsupported_tables", "adobefonts/STAT_strings"]
             .add_and_register_check(checks::adobefonts::family::consistent_upm)
             .add_and_register_check(checks::adobefonts::nameid_1_win_english)
             .add_and_register_check(checks::adobefonts::unsupported_tables)
-            .add_and_register_check(checks::adobefonts::STAT_strings)
             .exclude_check("opentype/xavgcharwidth")
             .exclude_check("designspace_has_consistent_codepoints")
             .exclude_check("designspace_has_consistent_glyphset")
@@ -27,7 +27,6 @@ impl fontspector_checkapi::ProfileProvider for Adobe {
             .exclude_check("ufo_recommended_fields")
             .exclude_check("ufo_required_fields")
             .exclude_check("ufo_unnecessary_fields")
-            .exclude_check("STAT_strings")
             .exclude_check("transformed_components")
             .exclude_check("unreachable_glyphs")
             .exclude_check("whitespace_ink")

--- a/profile-googlefonts/src/checks/STAT_strings.rs
+++ b/profile-googlefonts/src/checks/STAT_strings.rs
@@ -5,14 +5,10 @@ use itertools::Itertools;
 use skrifa::raw::{tables::stat::AxisValue, TableProvider};
 
 #[check(
-    id = "adobefonts/STAT_strings",
+    id = "STAT_strings",
     rationale = "
-        
-        In the STAT table, the \"Italic\" keyword must not be used on AxisValues
-        for variation axes other than 'ital' or 'slnt'. This is a more lenient
-        implementation of googlefonts/STAT_strings which allows \"Italic\"
-        only for the 'ital' axis.
-    
+        On the STAT table, the \"Italic\" keyword must not be used on AxisValues
+        for variation axes other than 'ital'.
     ",
     proposal = "https://github.com/fonttools/fontbakery/issues/2863",
     title = "Check correctness of STAT table strings"
@@ -26,34 +22,28 @@ fn STAT_strings(t: &Testable, _context: &Context) -> CheckFnResult {
         .iter()
         .position(|axis| axis.axis_tag() == "ital")
         .map(|x| x as u16);
-    let slnt_pos = axes
-        .iter()
-        .position(|axis| axis.axis_tag() == "slnt")
-        .map(|x| x as u16);
     let mut name_ids = HashSet::new();
     if let Some(Ok(subtable)) = stat.offset_to_axis_values() {
         for axis_value in subtable.axis_values().iter().flatten() {
             match axis_value {
                 AxisValue::Format1(v) => {
-                    if Some(v.axis_index()) != ital_pos && Some(v.axis_index()) != slnt_pos {
+                    if Some(v.axis_index()) != ital_pos {
                         name_ids.insert(v.value_name_id());
                     }
                 }
                 AxisValue::Format2(v) => {
-                    if Some(v.axis_index()) != ital_pos && Some(v.axis_index()) != slnt_pos {
+                    if Some(v.axis_index()) != ital_pos {
                         name_ids.insert(v.value_name_id());
                     }
                 }
                 AxisValue::Format3(v) => {
-                    if Some(v.axis_index()) != ital_pos && Some(v.axis_index()) != slnt_pos {
+                    if Some(v.axis_index()) != ital_pos {
                         name_ids.insert(v.value_name_id());
                     }
                 }
                 AxisValue::Format4(v) => {
                     for axis_value in v.axis_values() {
-                        if Some(axis_value.axis_index()) != ital_pos
-                            && Some(axis_value.axis_index()) != slnt_pos
-                        {
+                        if Some(axis_value.axis_index()) != ital_pos {
                             name_ids.insert(v.value_name_id());
                         }
                     }
@@ -77,5 +67,25 @@ fn STAT_strings(t: &Testable, _context: &Context) -> CheckFnResult {
         ))
     } else {
         Ok(Status::just_one_pass())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fontspector_checkapi::codetesting::{
+        assert_pass, assert_results_contain, run_check, test_able,
+    };
+
+    use fontspector_checkapi::StatusCode;
+
+    #[test]
+    fn test_stat_strings() {
+        let testable = test_able("ibmplexsans-vf/IBMPlexSansVar-Roman.ttf");
+        let results = run_check(super::STAT_strings, testable);
+        assert_pass(&results);
+
+        let testable = test_able("ibmplexsans-vf/IBMPlexSansVar-Italic.ttf");
+        let results = run_check(super::STAT_strings, testable);
+        assert_results_contain(&results, StatusCode::Fail, Some("bad-italic".to_string()));
     }
 }

--- a/profile-googlefonts/src/checks/mod.rs
+++ b/profile-googlefonts/src/checks/mod.rs
@@ -10,3 +10,9 @@ pub mod shaping;
 mod soft_dotted;
 #[cfg(feature = "check")]
 pub use soft_dotted::soft_dotted;
+
+#[allow(non_snake_case)]
+#[cfg(feature = "check")]
+mod STAT_strings;
+#[cfg(feature = "check")]
+pub use STAT_strings::STAT_strings;

--- a/profile-googlefonts/src/lib.rs
+++ b/profile-googlefonts/src/lib.rs
@@ -40,7 +40,9 @@ impl fontspector_checkapi::ProfileProvider for GoogleFonts {
         cr.register_filetype("IMAGE", IMAGE);
         cr.register_filetype("LICENSE", LICENSE);
 
-        let builder = ProfileBuilder::new().include_profile("universal");
+        let builder = ProfileBuilder::new()
+            .include_profile("universal")
+            .exclude_check("adobefonts/STAT_strings"); // We have our own stricter version
 
         #[cfg(feature = "check")]
         let builder = builder
@@ -51,30 +53,14 @@ impl fontspector_checkapi::ProfileProvider for GoogleFonts {
 
         #[cfg(feature = "check")]
         let builder = builder.add_and_register_check(checks::googlefonts::metadata::axes);
-        //            checks::googlefonts::metadata::axisregistry_bounds // Merged into metadata/axes
-        //            checks::googlefonts::metadata::axisregistry_valid_tags // Merged into metadata/axes
-        //            checks::googlefonts::metadata::consistent_axis_enumeration // Merged into metadata/axes
         #[cfg(all(feature = "check", not(target_family = "wasm")))]
         let builder = builder.add_and_register_check(checks::googlefonts::metadata::broken_links);
         #[cfg(feature = "check")]
         let builder = builder
-            //            checks::googlefonts::metadata::canonical_weight_value // Merged into metadata/validate
-            //            checks::googlefonts::metadata::designer_values // Merged into metadata/validate
-            //            checks::googlefonts::metadata::empty_designer // Merged into metadata/validate
             .add_and_register_check(checks::googlefonts::metadata::can_render_samples)
             .add_and_register_check(checks::googlefonts::metadata::category)
-            //            checks::googlefonts::metadata::category_hints // merged into metadata/validate
             .add_and_register_check(checks::googlefonts::metadata::consistent_repo_urls)
             .add_and_register_check(checks::googlefonts::metadata::consistent_with_fonts);
-        //            checks::googlefonts::metadata::filenames // merged into metadata/consistent_with_fonts
-        //            checks::googlefonts::metadata::canonical_style_names // merged into metadata/consistent_with_fonts
-        //            checks::googlefonts::metadata::valid_full_name_values // merged into metadata/consistent_with_fonts
-        //            checks::googlefonts::metadata::nameid/post_script_name // merged into metadata/consistent_with_fonts
-        //            checks::googlefonts::metadata::valid_post_script_name_values // merged into metadata/consistent_with_fonts
-        //            checks::googlefonts::metadata::nameid/family_and_full_names // merged into metadata/consistent_with_fonts
-        //            checks::googlefonts::metadata::valid_filename_values // redundant, see fontbakery#4997
-        //            checks::googlefonts::metadata::undeclared_fonts // redundant, see fontbakery#4997
-        //            checks::googlefonts::metadata::nameid/font_name // redundant, see fontbakery#4581
         #[cfg(all(feature = "check", not(target_family = "wasm")))]
         let builder =
             builder.add_and_register_check(checks::googlefonts::metadata::designer_profiles);
@@ -85,18 +71,10 @@ impl fontspector_checkapi::ProfileProvider for GoogleFonts {
             .add_and_register_check(checks::googlefonts::metadata::family_directory_name)
             .add_and_register_check(checks::googlefonts::metadata::familyname)
             .add_and_register_check(checks::googlefonts::metadata::has_regular)
-            //            checks::googlefonts::metadata::match_filename_postscript // Merged into metadata/validate
-            //            checks::googlefonts::metadata::match_fullname_postscript // Merged into metadata/validate
-            //            checks::googlefonts::metadata::match_name_familyname // Merged into metadata/validate
-            //            checks::googlefonts::metadata::match_weight_postscript // Merged into metadata/validate
-            //            checks::googlefonts::metadata::minisite_url // Merged into metadata/validate
-            //            checks::googlefonts::metadata::unique_full_name_values // Merged into metadata/validate
-            //            checks::googlefonts::metadata::unique_weight_style_pairs // Merged into metadata/validate
             .add_and_register_check(checks::googlefonts::metadata::primary_script)
             .add_and_register_check(checks::googlefonts::metadata::valid_primary_script_language)
             .add_and_register_check(checks::googlefonts::metadata::regular_is_400)
             .add_and_register_check(checks::googlefonts::metadata::subsets_correct) // Replacement for metadata/unsupported_subsets
-            //            checks::googlefonts::metadata::single_cjk_subset // Merged into metadata/subsets_correct
             .add_and_register_check(checks::googlefonts::metadata::unreachable_subsetting)
             .add_and_register_check(checks::googlefonts::metadata::validate)
             .add_and_register_check(checks::googlefonts::metadata::valid_nameid25)
@@ -159,10 +137,6 @@ impl fontspector_checkapi::ProfileProvider for GoogleFonts {
             .add_and_register_check(checks::googlefonts::repo::ascii_filenames)
             .add_and_register_check(checks::googlefonts::repo::dirname_matches_nameid_1)
             .add_and_register_check(checks::googlefonts::repo::vf_has_static_fonts)
-            //            checks::googlefonts::repo::fb_report // Upstream repos should be checked separately
-            //            checks::googlefonts::repo::sample_image // Upstream repos should be checked separately
-            //            checks::googlefonts::repo::upstream_yaml_has_required_fields // Redundant, no upstream.yaml any more
-            //            checks::googlefonts::repo::zip_files // Upstream repos should be checked separately
             .add_section("Shaping Checks")
             .add_and_register_check(checks::dotted_circle);
 
@@ -216,17 +190,14 @@ impl fontspector_checkapi::ProfileProvider for GoogleFonts {
             .add_and_register_check(checks::googlefonts::name::illegal_particles)
             .add_and_register_check(checks::googlefonts::name::version_format)
             .add_and_register_check(checks::googlefonts::parametric_axes_hidden)
-            // checks::googlefonts::production_encoded_glyphs // DISABLED
-            // checks::googlefonts::production_glyphs_similarity // Unlikely to be useful in the short term
-            // checks::googlefonts::description::family_update // Unlikely to useful yet
             .add_and_register_check(checks::googlefonts::render_own_name)
             .add_and_register_check(checks::googlefonts::STAT::axis_order)
             .add_and_register_check(checks::googlefonts::STAT::axisregistry)
             .add_and_register_check(checks::googlefonts::STAT::compulsory_axis_values)
             .add_and_register_check(checks::googlefonts::STAT::opsz_not_elided)
+            .add_and_register_check(checks::STAT_strings)
             .add_and_register_check(checks::googlefonts::unitsperem)
             .add_and_register_check(checks::googlefonts::use_typo_metrics)
-            // Not porting generate_static, see fontbakery#1727
             .add_and_register_check(checks::googlefonts::varfont::has_HVAR)
             .add_and_register_check(checks::googlefonts::varfont::slnt_needs_italic)
             .add_and_register_check(checks::googlefonts::vendor_id)

--- a/profile-universal/src/checks/STAT_strings.rs
+++ b/profile-universal/src/checks/STAT_strings.rs
@@ -5,10 +5,14 @@ use itertools::Itertools;
 use skrifa::raw::{tables::stat::AxisValue, TableProvider};
 
 #[check(
-    id = "STAT_strings",
+    id = "adobefonts/STAT_strings",
     rationale = "
-        On the STAT table, the \"Italic\" keyword must not be used on AxisValues
-        for variation axes other than 'ital'.
+        
+        In the STAT table, the \"Italic\" keyword must not be used on AxisValues
+        for variation axes other than 'ital' or 'slnt'. This is a more lenient
+        implementation of googlefonts/STAT_strings which allows \"Italic\"
+        only for the 'ital' axis.
+    
     ",
     proposal = "https://github.com/fonttools/fontbakery/issues/2863",
     title = "Check correctness of STAT table strings"
@@ -22,28 +26,34 @@ fn STAT_strings(t: &Testable, _context: &Context) -> CheckFnResult {
         .iter()
         .position(|axis| axis.axis_tag() == "ital")
         .map(|x| x as u16);
+    let slnt_pos = axes
+        .iter()
+        .position(|axis| axis.axis_tag() == "slnt")
+        .map(|x| x as u16);
     let mut name_ids = HashSet::new();
     if let Some(Ok(subtable)) = stat.offset_to_axis_values() {
         for axis_value in subtable.axis_values().iter().flatten() {
             match axis_value {
                 AxisValue::Format1(v) => {
-                    if Some(v.axis_index()) != ital_pos {
+                    if Some(v.axis_index()) != ital_pos && Some(v.axis_index()) != slnt_pos {
                         name_ids.insert(v.value_name_id());
                     }
                 }
                 AxisValue::Format2(v) => {
-                    if Some(v.axis_index()) != ital_pos {
+                    if Some(v.axis_index()) != ital_pos && Some(v.axis_index()) != slnt_pos {
                         name_ids.insert(v.value_name_id());
                     }
                 }
                 AxisValue::Format3(v) => {
-                    if Some(v.axis_index()) != ital_pos {
+                    if Some(v.axis_index()) != ital_pos && Some(v.axis_index()) != slnt_pos {
                         name_ids.insert(v.value_name_id());
                     }
                 }
                 AxisValue::Format4(v) => {
                     for axis_value in v.axis_values() {
-                        if Some(axis_value.axis_index()) != ital_pos {
+                        if Some(axis_value.axis_index()) != ital_pos
+                            && Some(axis_value.axis_index()) != slnt_pos
+                        {
                             name_ids.insert(v.value_name_id());
                         }
                     }
@@ -67,25 +77,5 @@ fn STAT_strings(t: &Testable, _context: &Context) -> CheckFnResult {
         ))
     } else {
         Ok(Status::just_one_pass())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use fontspector_checkapi::codetesting::{
-        assert_pass, assert_results_contain, run_check, test_able,
-    };
-
-    use fontspector_checkapi::StatusCode;
-
-    #[test]
-    fn test_stat_strings() {
-        let testable = test_able("ibmplexsans-vf/IBMPlexSansVar-Roman.ttf");
-        let results = run_check(super::STAT_strings, testable);
-        assert_pass(&results);
-
-        let testable = test_able("ibmplexsans-vf/IBMPlexSansVar-Italic.ttf");
-        let results = run_check(super::STAT_strings, testable);
-        assert_results_contain(&results, StatusCode::Fail, Some("bad-italic".to_string()));
     }
 }


### PR DESCRIPTION
Rutherford Craze (MD) noticed that our default STAT_strings implementation was restrictive - it stops "Italic" being a name on the "slnt" axis, which he (and [apparently others](https://github.com/fonttools/fontbakery/issues/4199)) wanted to do. Adobe had a separate, less restrictive implementation specifically to allow that case. It turns out in that FB issue, the restriction we put on was GF-specific. So let's promote Adobe's implementation to the default, and move our more restrictive one to GF.